### PR TITLE
Add verify option

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -7,6 +7,25 @@ const Ajv = require('ajv');
 const program = new Command();
 const schema = require('../scjson.schema.json');
 
+function removeEmpty(value) {
+  if (Array.isArray(value)) {
+    const arr = value.map(removeEmpty).filter(v => v !== undefined);
+    return arr.length > 0 ? arr : undefined;
+  }
+  if (value && typeof value === 'object') {
+    const obj = {};
+    for (const [k, v] of Object.entries(value)) {
+      const r = removeEmpty(v);
+      if (r !== undefined) obj[k] = r;
+    }
+    return Object.keys(obj).length > 0 ? obj : undefined;
+  }
+  if (value === null) {
+    return undefined;
+  }
+  return value;
+}
+
 program
   .name('scjson')
   .description('SCXML <-> scjson converter and validator');
@@ -33,19 +52,38 @@ program.command('convert')
   .requiredOption('--to <format>', 'target format (scxml|scjson)')
   .requiredOption('--input <file>', 'input file path')
   .requiredOption('--output <file>', 'output file path')
+  .option('-v, --verify', 'verify conversion without writing output')
+  .option('--keep-empty', 'keep null or empty items when generating JSON')
   .action((opts) => {
     const from = opts.from.toLowerCase();
     const to = opts.to.toLowerCase();
+    const verify = opts.verify || false;
+    const keepEmpty = opts.keepEmpty || false;
     if (from === 'scxml' && to === 'scjson') {
       const xml = fs.readFileSync(opts.input, 'utf8');
       const parser = new XMLParser();
-      const obj = parser.parse(xml);
-      fs.writeFileSync(opts.output, JSON.stringify(obj, null, 2));
+      let obj = parser.parse(xml);
+      if (!keepEmpty) {
+        obj = removeEmpty(obj) || {};
+      }
+      if (verify) {
+        const builder = new XMLBuilder({ ignoreAttributes: false, format: true });
+        builder.build(obj);
+        console.log('Verified');
+      } else {
+        fs.writeFileSync(opts.output, JSON.stringify(obj, null, 2));
+      }
     } else if (from === 'scjson' && to === 'scxml') {
       const json = JSON.parse(fs.readFileSync(opts.input, 'utf8'));
       const builder = new XMLBuilder({ ignoreAttributes: false, format: true });
       const xml = builder.build(json);
-      fs.writeFileSync(opts.output, xml);
+      if (verify) {
+        const parser = new XMLParser();
+        parser.parse(xml);
+        console.log('Verified');
+      } else {
+        fs.writeFileSync(opts.output, xml);
+      }
     } else {
       console.error('Unsupported conversion');
       process.exitCode = 1;


### PR DESCRIPTION
## Summary
- support `--keep-empty` option to keep empty/null fields
- add omit-empty logic to `SCXMLDocumentHandler`
- test that reconverted SCXML matches the tutorial files

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68766ecf89bc8333ad6845b72cfc0a8f