### PR TITLE
Add scjson JS converter and tests

### DIFF
--- a/js/bin/scjson.js
+++ b/js/bin/scjson.js
@@ -1,3 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Agent Name: js-cli-runner
+ *
+ * Part of the scjson project.
+ * Developed by Softoboros Technology Inc.
+ * Licensed under the BSD 1-Clause License.
+ */
+
 const { program } = require('../index.js');
 program.parse(process.argv);

--- a/js/eslint.config.js
+++ b/js/eslint.config.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    ignores: ['node_modules/**'],
+    languageOptions: { ecmaVersion: 2020 },
+    rules: {},
+  },
+];

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,11 @@
+/**
+ * Agent Name: js-cli
+ *
+ * Part of the scjson project.
+ * Developed by Softoboros Technology Inc.
+ * Licensed under the BSD 1-Clause License.
+ */
+
 const fs = require('fs');
 const path = require('path');
 const { Command } = require('commander');
@@ -7,6 +15,12 @@ const Ajv = require('ajv');
 const program = new Command();
 const schema = require('../scjson.schema.json');
 
+/**
+ * Remove nulls and empty containers from values recursively.
+ *
+ * @param {*} value - Candidate value.
+ * @returns {*} Sanitised value.
+ */
 function removeEmpty(value) {
   if (Array.isArray(value)) {
     const arr = value.map(removeEmpty).filter(v => v !== undefined);
@@ -26,67 +40,184 @@ function removeEmpty(value) {
   return value;
 }
 
+const ajv = new Ajv({ useDefaults: true, strict: false });
+const validate = ajv.compile(schema);
+
+/**
+ * Convert an SCXML string to scjson.
+ *
+ * @param {string} xmlStr - XML input.
+ * @param {boolean} [omitEmpty=true] - Remove empty values when true.
+ * @returns {string} JSON representation.
+ */
+function xmlToJson(xmlStr, omitEmpty = true) {
+  const parser = new XMLParser({ ignoreAttributes: false });
+  let obj = parser.parse(xmlStr);
+  if (obj.scxml) {
+    obj = obj.scxml;
+  }
+  if (omitEmpty) {
+    obj = removeEmpty(obj) || {};
+  }
+  if (obj.version === undefined) {
+    obj.version = 1.0;
+  }
+  if (!validate(obj)) {
+    throw new Error('Invalid scjson');
+  }
+  return JSON.stringify(obj, null, 2);
+}
+
+/**
+ * Convert a scjson string to SCXML.
+ *
+ * @param {string} jsonStr - JSON input.
+ * @returns {string} XML output.
+ */
+function jsonToXml(jsonStr) {
+  const builder = new XMLBuilder({ ignoreAttributes: false, format: true });
+  const obj = JSON.parse(jsonStr);
+  if (!validate(obj)) {
+    throw new Error('Invalid scjson');
+  }
+  return builder.build({ scxml: obj });
+}
+
 program
   .name('scjson')
   .description('SCXML <-> scjson converter and validator');
 
-program.command('validate')
-  .description('validate a scjson file against the schema')
-  .argument('<file>', 'scjson file path')
-  .action((file) => {
-    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-    const ajv = new Ajv();
-    const validate = ajv.compile(schema);
-    if (validate(data)) {
-      console.log('Valid scjson');
+program
+  .command('validate')
+  .description('validate a scjson or SCXML file by round-tripping it')
+  .argument('<file>', 'file path')
+  .option('-r, --recursive', 'recurse into directories')
+  .action((file, options) => {
+    const src = path.resolve(file);
+    let success = true;
+
+    function validateFile(p) {
+      const data = fs.readFileSync(p, 'utf8');
+      try {
+        if (p.endsWith('.scxml')) {
+          const json = xmlToJson(data);
+          jsonToXml(json);
+        } else if (p.endsWith('.scjson')) {
+          const xml = jsonToXml(data);
+          xmlToJson(xml);
+        } else {
+          return;
+        }
+      } catch (e) {
+        console.error(`Validation failed for ${p}: ${e.message}`);
+        success = false;
+      }
+    }
+
+    if (fs.statSync(src).isDirectory()) {
+      const pattern = options.recursive ? '**/*' : '*';
+      const files = require('glob').sync(pattern, { cwd: src, nodir: true });
+      files.forEach(f => validateFile(path.join(src, f)));
     } else {
-      console.error('Invalid scjson');
-      console.error(validate.errors);
+      validateFile(src);
+    }
+
+    if (!success) {
       process.exitCode = 1;
     }
   });
 
-program.command('convert')
-  .description('convert between scxml and scjson')
-  .requiredOption('--from <format>', 'source format (scxml|scjson)')
-  .requiredOption('--to <format>', 'target format (scxml|scjson)')
-  .requiredOption('--input <file>', 'input file path')
-  .requiredOption('--output <file>', 'output file path')
-  .option('-v, --verify', 'verify conversion without writing output')
-  .option('--keep-empty', 'keep null or empty items when generating JSON')
-  .action((opts) => {
-    const from = opts.from.toLowerCase();
-    const to = opts.to.toLowerCase();
-    const verify = opts.verify || false;
-    const keepEmpty = opts.keepEmpty || false;
-    if (from === 'scxml' && to === 'scjson') {
-      const xml = fs.readFileSync(opts.input, 'utf8');
-      const parser = new XMLParser();
-      let obj = parser.parse(xml);
-      if (!keepEmpty) {
-        obj = removeEmpty(obj) || {};
-      }
-      if (verify) {
-        const builder = new XMLBuilder({ ignoreAttributes: false, format: true });
-        builder.build(obj);
-        console.log('Verified');
-      } else {
-        fs.writeFileSync(opts.output, JSON.stringify(obj, null, 2));
-      }
-    } else if (from === 'scjson' && to === 'scxml') {
-      const json = JSON.parse(fs.readFileSync(opts.input, 'utf8'));
-      const builder = new XMLBuilder({ ignoreAttributes: false, format: true });
-      const xml = builder.build(json);
-      if (verify) {
-        const parser = new XMLParser();
-        parser.parse(xml);
-        console.log('Verified');
-      } else {
-        fs.writeFileSync(opts.output, xml);
-      }
+function convertDirectoryJson(inputDir, outputDir, recursive, verify, keepEmpty) {
+  const pattern = recursive ? '**/*.scxml' : '*.scxml';
+  const files = require('glob').sync(pattern, { cwd: inputDir, nodir: true });
+  files.forEach(f => {
+    const src = path.join(inputDir, f);
+    const dest = path.join(outputDir, f.replace(/\.scxml$/, '.scjson'));
+    convertScxmlFile(src, dest, verify, keepEmpty);
+  });
+}
+
+function convertDirectoryXml(inputDir, outputDir, recursive, verify, keepEmpty) {
+  const pattern = recursive ? '**/*.scjson' : '*.scjson';
+  const files = require('glob').sync(pattern, { cwd: inputDir, nodir: true });
+  files.forEach(f => {
+    const src = path.join(inputDir, f);
+    const dest = path.join(outputDir, f.replace(/\.scjson$/, '.scxml'));
+    convertScjsonFile(src, dest, verify, keepEmpty);
+  });
+}
+
+function convertScxmlFile(src, dest, verify, keepEmpty) {
+  const xmlStr = fs.readFileSync(src, 'utf8');
+  try {
+    const jsonStr = xmlToJson(xmlStr, !keepEmpty);
+    if (verify) {
+      jsonToXml(jsonStr);
     } else {
-      console.error('Unsupported conversion');
-      process.exitCode = 1;
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, jsonStr);
+    }
+    if (verify) console.log(`Verified ${src}`);
+  } catch (e) {
+    console.error(`Failed to convert ${src}: ${e.message}`);
+  }
+}
+
+function convertScjsonFile(src, dest, verify) {
+  const jsonStr = fs.readFileSync(src, 'utf8');
+  try {
+    const xmlStr = jsonToXml(jsonStr);
+    if (verify) {
+      xmlToJson(xmlStr);
+    } else {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, xmlStr);
+    }
+    if (verify) console.log(`Verified ${src}`);
+  } catch (e) {
+    console.error(`Failed to convert ${src}: ${e.message}`);
+  }
+}
+
+program
+  .command('json')
+  .argument('<path>', 'SCXML file or directory')
+  .option('-o, --output <path>', 'output file or directory')
+  .option('-r, --recursive', 'recurse into directories')
+  .option('-v, --verify', 'verify conversion without writing output')
+  .option('--keep-empty', 'keep null or empty items when producing JSON')
+  .action((p, opts) => {
+    const src = path.resolve(p);
+    const out = opts.output ? path.resolve(opts.output) : src;
+
+    if (fs.statSync(src).isDirectory()) {
+      convertDirectoryJson(src, out, opts.recursive, opts.verify, opts.keepEmpty);
+    } else {
+      const dest = opts.output && !opts.output.endsWith('.json') && !opts.output.endsWith('.scjson')
+        ? path.join(out, path.basename(src).replace(/\.scxml$/, '.scjson'))
+        : (opts.output || src.replace(/\.scxml$/, '.scjson'));
+      convertScxmlFile(src, dest, opts.verify, opts.keepEmpty);
+    }
+  });
+
+program
+  .command('xml')
+  .argument('<path>', 'scjson file or directory')
+  .option('-o, --output <path>', 'output file or directory')
+  .option('-r, --recursive', 'recurse into directories')
+  .option('-v, --verify', 'verify conversion without writing output')
+  .option('--keep-empty', 'keep null or empty items when producing JSON')
+  .action((p, opts) => {
+    const src = path.resolve(p);
+    const out = opts.output ? path.resolve(opts.output) : src;
+
+    if (fs.statSync(src).isDirectory()) {
+      convertDirectoryXml(src, out, opts.recursive, opts.verify, opts.keepEmpty);
+    } else {
+      const dest = opts.output && !opts.output.endsWith('.xml') && !opts.output.endsWith('.scxml')
+        ? path.join(out, path.basename(src).replace(/\.scjson$/, '.scxml'))
+        : (opts.output || src.replace(/\.scjson$/, '.scxml'));
+      convertScjsonFile(src, dest, opts.verify, opts.keepEmpty);
     }
   });
 
@@ -94,4 +225,4 @@ if (require.main === module) {
   program.parse(process.argv);
 }
 
-module.exports = { program };
+module.exports = { program, xmlToJson, jsonToXml };

--- a/js/tests/cli.test.js
+++ b/js/tests/cli.test.js
@@ -1,8 +1,150 @@
-const { execSync } = require('child_process');
-const path = require('path');
+/**
+ * Agent Name: js-cli-tests
+ *
+ * Part of the scjson project.
+ * Developed by Softoboros Technology Inc.
+ * Licensed under the BSD 1-Clause License.
+ */
 
-test('shows help', () => {
-  const cliPath = path.resolve(__dirname, '../bin/scjson.js');
-  const out = execSync(`node ${cliPath} --help`).toString();
-  expect(out).toMatch(/convert/);
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const cliPath = path.resolve(__dirname, '../bin/scjson.js');
+
+function createScxml() {
+  return '<scxml xmlns="http://www.w3.org/2005/07/scxml"/>';
+}
+
+function createScjson() {
+  const json = {
+    version: 1,
+    datamodel_attribute: 'null',
+  };
+  return JSON.stringify(json, null, 2);
+}
+
+describe('scjson CLI', () => {
+  test('shows help', () => {
+    const out = execSync(`node ${cliPath} --help`).toString();
+    expect(out).toMatch(/scjson/);
+  });
+
+  test('single json conversion', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scjson-'));
+    const xmlPath = path.join(dir, 'sample.scxml');
+    fs.writeFileSync(xmlPath, createScxml());
+
+    execSync(`node ${cliPath} json ${xmlPath}`);
+
+    const outPath = path.join(dir, 'sample.scjson');
+    expect(fs.existsSync(outPath)).toBe(true);
+    const data = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    expect(data.version).toBe(1);
+  });
+
+  test('directory json conversion', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scjson-'));
+    const srcDir = path.join(dir, 'src');
+    fs.mkdirSync(srcDir);
+    ['a', 'b'].forEach(n => {
+      fs.writeFileSync(path.join(srcDir, `${n}.scxml`), createScxml());
+    });
+
+    execSync(`node ${cliPath} json ${srcDir}`);
+
+    ['a', 'b'].forEach(n => {
+      expect(fs.existsSync(path.join(srcDir, `${n}.scjson`))).toBe(true);
+    });
+  });
+
+  test('single xml conversion', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scjson-'));
+    const jsonPath = path.join(dir, 'sample.scjson');
+    fs.writeFileSync(jsonPath, createScjson());
+
+    execSync(`node ${cliPath} xml ${jsonPath}`);
+
+    const outPath = path.join(dir, 'sample.scxml');
+    expect(fs.existsSync(outPath)).toBe(true);
+    const data = fs.readFileSync(outPath, 'utf8');
+    expect(data).toMatch(/scxml/);
+  });
+
+  test('directory xml conversion', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scjson-'));
+    const srcDir = path.join(dir, 'jsons');
+    fs.mkdirSync(srcDir);
+    ['x', 'y'].forEach(n => {
+      fs.writeFileSync(path.join(srcDir, `${n}.scjson`), createScjson());
+    });
+
+    execSync(`node ${cliPath} xml ${srcDir}`);
+
+    ['x', 'y'].forEach(n => {
+      expect(fs.existsSync(path.join(srcDir, `${n}.scxml`))).toBe(true);
+    });
+  });
+
+  function buildDataset(base) {
+    const d1 = path.join(base, 'level1');
+    const d2 = path.join(d1, 'level2');
+    fs.mkdirSync(d2, { recursive: true });
+    ['a', 'b'].forEach(n => {
+      fs.writeFileSync(path.join(d1, `${n}.scxml`), createScxml());
+      fs.writeFileSync(path.join(d2, `${n}.scxml`), createScxml());
+    });
+  }
+
+  test('recursive conversion', () => {
+    const dataset = fs.mkdtempSync(path.join(os.tmpdir(), 'scjson-'));
+    buildDataset(dataset);
+    const scjsonDir = path.join(dataset, 'outjson');
+    const scxmlDir = path.join(dataset, 'outxml');
+
+    execSync(`node ${cliPath} json ${dataset} -o ${scjsonDir} -r`);
+    execSync(`node ${cliPath} xml ${scjsonDir} -o ${scxmlDir} -r`);
+
+    const jsonFiles = require('glob').sync('**/*.scjson', { cwd: scjsonDir, nodir: true });
+    const xmlFiles = require('glob').sync('**/*.scxml', { cwd: scxmlDir, nodir: true });
+
+    expect(jsonFiles.length).toBeGreaterThan(0);
+    expect(xmlFiles.length).toBeGreaterThan(0);
+    expect(xmlFiles.length).toBeLessThanOrEqual(jsonFiles.length);
+  });
+
+  test('recursive validation', () => {
+    const dataset = fs.mkdtempSync(path.join(os.tmpdir(), 'scjson-'));
+    buildDataset(dataset);
+    const scjsonDir = path.join(dataset, 'outjson');
+    const scxmlDir = path.join(dataset, 'outxml');
+
+    execSync(`node ${cliPath} json ${dataset} -o ${scjsonDir} -r`);
+    execSync(`node ${cliPath} xml ${scjsonDir} -o ${scxmlDir} -r`);
+
+    // Corrupt one file to trigger failure
+    fs.writeFileSync(path.join(scjsonDir, 'corrupt.scjson'), 'bad');
+
+    let failed = false;
+    try {
+      execSync(`node ${cliPath} validate ${dataset} -r`, { stdio: 'pipe' });
+    } catch {
+      failed = true;
+    }
+    expect(failed).toBe(true);
+  });
+
+  test('recursive verify', () => {
+    const dataset = fs.mkdtempSync(path.join(os.tmpdir(), 'scjson-'));
+    buildDataset(dataset);
+    const scjsonDir = path.join(dataset, 'outjson');
+    const scxmlDir = path.join(dataset, 'outxml');
+
+    execSync(`node ${cliPath} json ${dataset} -o ${scjsonDir} -r`);
+    execSync(`node ${cliPath} xml ${scjsonDir} -o ${scxmlDir} -r`);
+
+    execSync(`node ${cliPath} json ${scxmlDir} -r -v`);
+    execSync(`node ${cliPath} xml ${scjsonDir} -r -v`);
+  });
 });


### PR DESCRIPTION
## Summary
- implement scjson CLI in JS using Ajv with defaults
- support xml/json conversion and validation
- add jest tests mirroring python suite
- add simple eslint config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68767e86a7c483339a22701e73c98020