### PR TITLE
Add Go conversion CLI

### DIFF
--- a/go/cli_test.go
+++ b/go/cli_test.go
@@ -1,0 +1,117 @@
+/*
+Agent Name: go-cli-tests
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func createScxml() string {
+	return `<scxml xmlns="http://www.w3.org/2005/07/scxml"/>`
+}
+
+func createScjson() string {
+	obj := map[string]interface{}{
+		"version":             1.0,
+		"datamodel_attribute": "null",
+	}
+	b, _ := json.MarshalIndent(obj, "", "  ")
+	return string(b)
+}
+
+func TestSingleJsonConversion(t *testing.T) {
+	dir := t.TempDir()
+	xmlPath := filepath.Join(dir, "sample.scxml")
+	os.WriteFile(xmlPath, []byte(createScxml()), 0o644)
+
+	cmd := exec.Command("go", "run", ".", "json", xmlPath)
+	cmd.Dir = "./"
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command failed: %v, out=%s", err, string(out))
+	}
+
+	outPath := filepath.Join(dir, "sample.scjson")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("output not found: %v", err)
+	}
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+	if m["version"] != 1.0 {
+		t.Errorf("expected version 1.0")
+	}
+}
+
+func TestDirectoryJsonConversion(t *testing.T) {
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	os.Mkdir(srcDir, 0o755)
+	for _, n := range []string{"a", "b"} {
+		os.WriteFile(filepath.Join(srcDir, n+".scxml"), []byte(createScxml()), 0o644)
+	}
+
+	cmd := exec.Command("go", "run", ".", "json", srcDir)
+	cmd.Dir = "./"
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command failed: %v, %s", err, string(out))
+	}
+	for _, n := range []string{"a", "b"} {
+		if _, err := os.Stat(filepath.Join(srcDir, n+".scjson")); err != nil {
+			t.Errorf("missing %s.scjson", n)
+		}
+	}
+}
+
+func TestSingleXmlConversion(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "sample.scjson")
+	os.WriteFile(jsonPath, []byte(createScjson()), 0o644)
+
+	cmd := exec.Command("go", "run", ".", "xml", jsonPath)
+	cmd.Dir = "./"
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command failed: %v, %s", err, string(out))
+	}
+	outPath := filepath.Join(dir, "sample.scxml")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("output not found: %v", err)
+	}
+	if string(data) == "" {
+		t.Errorf("no data")
+	}
+}
+
+func TestDirectoryXmlConversion(t *testing.T) {
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "jsons")
+	os.Mkdir(srcDir, 0o755)
+	for _, n := range []string{"x", "y"} {
+		os.WriteFile(filepath.Join(srcDir, n+".scjson"), []byte(createScjson()), 0o644)
+	}
+
+	cmd := exec.Command("go", "run", ".", "xml", srcDir)
+	cmd.Dir = "./"
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command failed: %v, %s", err, string(out))
+	}
+	for _, n := range []string{"x", "y"} {
+		if _, err := os.Stat(filepath.Join(srcDir, n+".scxml")); err != nil {
+			t.Errorf("missing %s.scxml", n)
+		}
+	}
+}

--- a/go/converter.go
+++ b/go/converter.go
@@ -1,0 +1,145 @@
+/*
+Agent Name: go-converter
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	mxj "github.com/clbanning/mxj/v2"
+)
+
+// removeEmpty removes nil or empty values recursively.
+//
+// @param v any - value to clean.
+// @returns any - cleaned value.
+func removeEmpty(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		cleaned := make(map[string]interface{})
+		for k, sub := range val {
+			r := removeEmpty(sub)
+			switch rv := r.(type) {
+			case nil:
+				continue
+			case map[string]interface{}:
+				if len(rv) == 0 {
+					continue
+				}
+			case []interface{}:
+				if len(rv) == 0 {
+					continue
+				}
+			}
+			cleaned[k] = r
+		}
+		if len(cleaned) == 0 {
+			return nil
+		}
+		return cleaned
+	case []interface{}:
+		var arr []interface{}
+		for _, sub := range val {
+			r := removeEmpty(sub)
+			if r != nil {
+				if arrMap, ok := r.(map[string]interface{}); ok && len(arrMap) == 0 {
+					continue
+				}
+				if arrSlice, ok := r.([]interface{}); ok && len(arrSlice) == 0 {
+					continue
+				}
+				arr = append(arr, r)
+			}
+		}
+		if len(arr) == 0 {
+			return nil
+		}
+		return arr
+	case string:
+		if val == "" {
+			return nil
+		}
+		return val
+	default:
+		if val == nil {
+			return nil
+		}
+		return val
+	}
+}
+
+// xmlToJSON converts an SCXML XML string to scjson JSON string.
+//
+// @param xmlStr string - xml input.
+// @param omitEmpty bool - if true, remove empty values.
+// @returns string - json output or error.
+func xmlToJSON(xmlStr string, omitEmpty bool) (string, error) {
+	mv, err := mxj.NewMapXml([]byte(xmlStr))
+	if err != nil {
+		return "", err
+	}
+	m := mv.Old()
+	if scxml, ok := m["scxml"].(map[string]interface{}); ok {
+		m = scxml
+	}
+	if omitEmpty {
+		m = removeEmpty(m).(map[string]interface{})
+	}
+	if _, ok := m["-xmlns"]; ok {
+		delete(m, "-xmlns")
+	}
+	if _, ok := m["version"]; !ok {
+		m["version"] = 1.0
+	}
+	if _, ok := m["datamodel_attribute"]; !ok {
+		m["datamodel_attribute"] = "null"
+	}
+	if omitEmpty {
+		m = removeEmpty(m).(map[string]interface{})
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// jsonToXML converts a scjson string to SCXML XML string.
+//
+// @param jsonStr string - json input.
+// @returns string - xml output or error.
+func jsonToXML(jsonStr string) (string, error) {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		return "", err
+	}
+	mv := mxj.Map{"scxml": m}
+	bytes, err := mv.XmlIndent("", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+// writeFile writes data to the destination path, ensuring directories exist.
+//
+// @param dest string - destination path.
+// @param data string - data to write.
+// @returns error - failure if any.
+func writeFile(dest, data string) error {
+	if dest == "" {
+		return errors.New("destination path required")
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dest, []byte(data), 0o644)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,11 @@
+module scjson/go
+
+go 1.24.3
+
+require (
+	github.com/clbanning/mxj/v2 v2.7.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/urfave/cli/v2 v2.27.7 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,10 @@
+github.com/clbanning/mxj/v2 v2.7.0 h1:WA/La7UGCanFe5NpHF0Q3DNtnCsVoxbPKuyBNHWRyME=
+github.com/clbanning/mxj/v2 v2.7.0/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
+github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
+github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
+github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,274 @@
+/*
+Agent Name: go-cli
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	cli "github.com/urfave/cli/v2"
+)
+
+// convertScxmlFile converts a single SCXML file to scjson.
+//
+// @param src string - path to SCXML file.
+// @param dest string - destination path.
+// @param verify bool - verify only.
+// @param keepEmpty bool - keep empty fields.
+// @returns error - failure if any.
+func convertScxmlFile(src, dest string, verify, keepEmpty bool) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	jsonStr, err := xmlToJSON(string(data), !keepEmpty)
+	if err != nil {
+		return err
+	}
+	if verify {
+		if _, err := jsonToXML(jsonStr); err != nil {
+			return err
+		}
+		fmt.Printf("Verified %s\n", src)
+		return nil
+	}
+	if dest == "" {
+		dest = filepath.Join(filepath.Dir(src), filepath.Base(src[:len(src)-len(filepath.Ext(src))])+".scjson")
+	}
+	return writeFile(dest, jsonStr)
+}
+
+// convertScjsonFile converts a single scjson file to SCXML.
+//
+// @param src string - path to scjson file.
+// @param dest string - destination path.
+// @param verify bool - verify only.
+// @returns error - failure if any.
+func convertScjsonFile(src, dest string, verify bool) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	xmlStr, err := jsonToXML(string(data))
+	if err != nil {
+		return err
+	}
+	if verify {
+		if _, err := xmlToJSON(xmlStr, true); err != nil {
+			return err
+		}
+		fmt.Printf("Verified %s\n", src)
+		return nil
+	}
+	if dest == "" {
+		dest = filepath.Join(filepath.Dir(src), filepath.Base(src[:len(src)-len(filepath.Ext(src))])+".scxml")
+	}
+	return writeFile(dest, xmlStr)
+}
+
+func main() {
+	app := &cli.App{
+		Name:  "scjson",
+		Usage: "SCXML <-> scjson converter and validator",
+	}
+
+	app.Commands = []*cli.Command{
+		{
+			Name:  "json",
+			Usage: "Convert SCXML to scjson",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "output", Aliases: []string{"o"}},
+				&cli.BoolFlag{Name: "recursive", Aliases: []string{"r"}},
+				&cli.BoolFlag{Name: "verify", Aliases: []string{"v"}},
+				&cli.BoolFlag{Name: "keep-empty"},
+			},
+			Action: func(c *cli.Context) error {
+				p := c.Args().First()
+				if p == "" {
+					return cli.Exit("path required", 1)
+				}
+				src, err := filepath.Abs(p)
+				if err != nil {
+					return err
+				}
+				out := c.String("output")
+				info, err := os.Stat(src)
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					destDir := src
+					if out != "" {
+						destDir, _ = filepath.Abs(out)
+					}
+					pattern := "*.scxml"
+					if c.Bool("recursive") {
+						pattern = "**/*.scxml"
+					}
+					matches, _ := filepath.Glob(filepath.Join(src, pattern))
+					for _, f := range matches {
+						if fi, err := os.Stat(f); err == nil && !fi.IsDir() {
+							rel, _ := filepath.Rel(src, f)
+							var dest string
+							if c.Bool("verify") {
+								dest = ""
+							} else {
+								dest = filepath.Join(destDir, rel[:len(rel)-len(filepath.Ext(rel))]+".scjson")
+							}
+							if err := convertScxmlFile(f, dest, c.Bool("verify"), c.Bool("keep-empty")); err != nil {
+								fmt.Fprintf(os.Stderr, "Failed to convert %s: %v\n", f, err)
+							}
+						}
+					}
+					return nil
+				}
+				dest := out
+				if !c.Bool("verify") && dest == "" {
+					dest = src[:len(src)-len(filepath.Ext(src))] + ".scjson"
+				}
+				return convertScxmlFile(src, dest, c.Bool("verify"), c.Bool("keep-empty"))
+			},
+		},
+		{
+			Name:  "xml",
+			Usage: "Convert scjson to SCXML",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "output", Aliases: []string{"o"}},
+				&cli.BoolFlag{Name: "recursive", Aliases: []string{"r"}},
+				&cli.BoolFlag{Name: "verify", Aliases: []string{"v"}},
+				&cli.BoolFlag{Name: "keep-empty"},
+			},
+			Action: func(c *cli.Context) error {
+				p := c.Args().First()
+				if p == "" {
+					return cli.Exit("path required", 1)
+				}
+				src, err := filepath.Abs(p)
+				if err != nil {
+					return err
+				}
+				out := c.String("output")
+				info, err := os.Stat(src)
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					destDir := src
+					if out != "" {
+						destDir, _ = filepath.Abs(out)
+					}
+					pattern := "*.scjson"
+					if c.Bool("recursive") {
+						pattern = "**/*.scjson"
+					}
+					matches, _ := filepath.Glob(filepath.Join(src, pattern))
+					for _, f := range matches {
+						if fi, err := os.Stat(f); err == nil && !fi.IsDir() {
+							rel, _ := filepath.Rel(src, f)
+							var dest string
+							if c.Bool("verify") {
+								dest = ""
+							} else {
+								dest = filepath.Join(destDir, rel[:len(rel)-len(filepath.Ext(rel))]+".scxml")
+							}
+							if err := convertScjsonFile(f, dest, c.Bool("verify")); err != nil {
+								fmt.Fprintf(os.Stderr, "Failed to convert %s: %v\n", f, err)
+							}
+						}
+					}
+					return nil
+				}
+				dest := out
+				if !c.Bool("verify") && dest == "" {
+					dest = src[:len(src)-len(filepath.Ext(src))] + ".scxml"
+				}
+				return convertScjsonFile(src, dest, c.Bool("verify"))
+			},
+		},
+		{
+			Name:  "validate",
+			Usage: "Validate scjson or SCXML files by round-tripping them",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: "recursive", Aliases: []string{"r"}},
+			},
+			Action: func(c *cli.Context) error {
+				p := c.Args().First()
+				if p == "" {
+					return cli.Exit("path required", 1)
+				}
+				src, err := filepath.Abs(p)
+				if err != nil {
+					return err
+				}
+				success := true
+				handle := func(f string) {
+					data, err := os.ReadFile(f)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Validation failed for %s: %v\n", f, err)
+						success = false
+						return
+					}
+					if filepath.Ext(f) == ".scxml" {
+						jsonStr, err := xmlToJSON(string(data), true)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "Validation failed for %s: %v\n", f, err)
+							success = false
+							return
+						}
+						if _, err := jsonToXML(jsonStr); err != nil {
+							fmt.Fprintf(os.Stderr, "Validation failed for %s: %v\n", f, err)
+							success = false
+							return
+						}
+					} else if filepath.Ext(f) == ".scjson" {
+						xmlStr, err := jsonToXML(string(data))
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "Validation failed for %s: %v\n", f, err)
+							success = false
+							return
+						}
+						if _, err := xmlToJSON(xmlStr, true); err != nil {
+							fmt.Fprintf(os.Stderr, "Validation failed for %s: %v\n", f, err)
+							success = false
+							return
+						}
+					}
+				}
+				info, err := os.Stat(src)
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					pattern := "*"
+					if c.Bool("recursive") {
+						pattern = "**/*"
+					}
+					matches, _ := filepath.Glob(filepath.Join(src, pattern))
+					for _, f := range matches {
+						if fi, err := os.Stat(f); err == nil && !fi.IsDir() {
+							handle(f)
+						}
+					}
+				} else {
+					handle(src)
+				}
+				if !success {
+					return cli.Exit("validation failed", 1)
+				}
+				return nil
+			},
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- create Go module with CLI for SCXML <-> scjson conversions
- implement conversion helpers and tests
- wire up Go tests to run from module directory
- include go.mod/go.sum with dependencies

## Testing
- `go test`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687699b709588333beb808510096a33d