### PR TITLE
Improve Lua SCJSON conversion

### DIFF
--- a/lua/scjson.lua
+++ b/lua/scjson.lua
@@ -15,23 +15,156 @@ local json = require('dkjson')
 
 local scjson = {}
 
+--- Recursively remove nil, empty strings, and empty tables.
+-- @param value any value to clean
+-- @return any sanitized value or nil
+local function remove_empty(value)
+    if type(value) == 'table' then
+        local is_array = #value > 0
+        if is_array then
+            local arr = {}
+            for _, v in ipairs(value) do
+                local r = remove_empty(v)
+                if r ~= nil then
+                    table.insert(arr, r)
+                end
+            end
+            if #arr == 0 then
+                return nil
+            end
+            return arr
+        else
+            local obj = {}
+            for k, v in pairs(value) do
+                local r = remove_empty(v)
+                if r ~= nil then
+                    obj[k] = r
+                end
+            end
+            if next(obj) == nil then
+                return nil
+            end
+            return obj
+        end
+    elseif value == nil or value == '' then
+        return nil
+    else
+        return value
+    end
+end
+
+--- Convert an lxp element to a Lua table.
+-- @param node table parsed lxp node
+-- @return table equivalent Lua table
+local function elem_to_table(node)
+    local t = {}
+    if node.attr then
+        for k, v in pairs(node.attr) do
+            if type(k) == 'string' then
+                t[k] = v
+            end
+        end
+    end
+    for _, child in ipairs(node) do
+        if type(child) == 'table' then
+            local val = elem_to_table(child)
+            if t[child.tag] then
+                if type(t[child.tag]) == 'table' and t[child.tag][1] then
+                    table.insert(t[child.tag], val)
+                else
+                    t[child.tag] = { t[child.tag], val }
+                end
+            else
+                t[child.tag] = val
+            end
+        elseif type(child) == 'string' then
+            local text = child:match('^%s*(.-)%s*$')
+            if text ~= '' then
+                if t.text then
+                    t.text = t.text .. text
+                else
+                    t.text = text
+                end
+            end
+        end
+    end
+    return t
+end
+
 --- Convert an SCXML string to a scjson string.
 -- @param xml_str string XML document
+-- @param omit_empty boolean remove empty values when true
 -- @return string scjson representation
-function scjson.xml_to_json(xml_str)
-    local t = { version = 1.0 }
-    return json.encode(t, { indent = true })
+function scjson.xml_to_json(xml_str, omit_empty)
+    local root = lxp.parse(xml_str)
+    local obj = elem_to_table(root)
+    obj.xmlns = nil
+    if obj.datamodel then
+        obj.datamodel_attribute = obj.datamodel
+        obj.datamodel = nil
+    end
+    if not obj.version then
+        obj.version = 1.0
+    end
+    if not obj.datamodel_attribute then
+        obj.datamodel_attribute = 'null'
+    end
+    if omit_empty == nil then
+        omit_empty = true
+    end
+    if omit_empty then
+        obj = remove_empty(obj) or {}
+    end
+    return json.encode(obj, { indent = true })
 end
 
 --- Convert a scjson string to an SCXML string.
 -- @param json_str string scjson document
 -- @return string XML representation
 function scjson.json_to_xml(json_str)
-    local t, pos, err = json.decode(json_str, 1, nil)
-    if err then
-        error(err)
+    local obj, pos, err = json.decode(json_str, 1, nil)
+    if err then error(err) end
+    if obj.datamodel_attribute then
+        obj.datamodel = obj.datamodel_attribute
+        obj.datamodel_attribute = nil
     end
-    return '<scxml xmlns="http://www.w3.org/2005/07/scxml"/>'
+    obj.xmlns = obj.xmlns or 'http://www.w3.org/2005/07/scxml'
+    local function build(tag, tbl, indent)
+        indent = indent or ''
+        local attrs = {}
+        local children = {}
+        local text = tbl.text
+        for k, v in pairs(tbl) do
+            if k ~= 'text' then
+                if type(v) == 'table' then
+                    children[k] = v
+                else
+                    table.insert(attrs, string.format(' %s="%s"', k, tostring(v)))
+                end
+            end
+        end
+        local parts = { indent, '<', tag, table.concat(attrs), '>' }
+        if text then
+            table.insert(parts, text)
+        end
+        for k, v in pairs(children) do
+            if v[1] then
+                for _, item in ipairs(v) do
+                    table.insert(parts, '\n')
+                    table.insert(parts, build(k, item, indent .. '  '))
+                end
+            else
+                table.insert(parts, '\n')
+                table.insert(parts, build(k, v, indent .. '  '))
+            end
+        end
+        if next(children) then
+            table.insert(parts, '\n' .. indent)
+        end
+        table.insert(parts, '</' .. tag .. '>')
+        return table.concat(parts)
+    end
+    return build('scxml', obj, '')
 end
 
 return scjson

--- a/lua/tests/scjson_spec.lua
+++ b/lua/tests/scjson_spec.lua
@@ -10,15 +10,20 @@ describe('cli', function()
     package.path = 'lua/?.lua;' .. package.path
     local scjson = require('scjson')
 
-    it('converts xml to json', function()
+    it('converts xml to json with defaults', function()
         local xml = '<scxml xmlns="http://www.w3.org/2005/07/scxml"/>'
-        local json = scjson.xml_to_json(xml)
-        assert.is.truthy(json:find('"version"'))
+        local j = scjson.xml_to_json(xml)
+        local data = require("dkjson").decode(j)
+        assert.are.equal(1.0, data.version)
+        assert.are.equal('null', data.datamodel_attribute)
     end)
 
-    it('converts json to xml', function()
-        local json = '{"version":1.0}'
-        local xml = scjson.json_to_xml(json)
-        assert.is.truthy(xml:find('scxml'))
+    it('roundtrips json and xml', function()
+        local obj = { version = 1.0, datamodel_attribute = 'null', state = { id = 'a' } }
+        local json_str = require('dkjson').encode(obj)
+        local xml = scjson.json_to_xml(json_str)
+        assert.is.truthy(xml:find('<scxml'))
+        local back = scjson.xml_to_json(xml)
+        assert.is.truthy(back:find('"state"'))
     end)
 end)


### PR DESCRIPTION
## Summary
- adjust xml→json to capture `datamodel` attribute
- map `datamodel_attribute` back to `datamodel` when converting to XML
- refactor XML builder to handle attributes and children cleanly

## Testing
- `cd lua && busted -v tests`


------
https://chatgpt.com/codex/tasks/task_e_6876a468f48883338aea9df1b2fc58c1