### PR TITLE
Add Python package docs and legal

### DIFF
--- a/py/LEGAL.md
+++ b/py/LEGAL.md
@@ -1,0 +1,13 @@
+# Legal Information
+
+This package is distributed as part of the **scjson** project.
+All original code in this directory is released under the BSD&nbsp;1-Clause license.
+
+The package references assets from the W3C SCXML specification and includes
+examples derived from Alex Zhornyak's *SCXML Editor Tutorial*.
+Those third-party materials remain under their respective licenses as documented
+in the repository's top-level `LEGAL.md` file.
+
+For complete license terms please consult that document.
+
+

--- a/py/MANIFEST.in
+++ b/py/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LEGAL.md

--- a/py/README.md
+++ b/py/README.md
@@ -1,0 +1,35 @@
+# scjson Python Package
+
+This directory contains the Python implementation of **scjson**, a format for representing SCXML state machines in JSON. The package provides a command line interface and utility functions to convert between `.scxml` and `.scjson` files and to validate documents against the project's schema.
+
+## Installation
+
+```bash
+pip install scjson
+```
+
+You can also install from a checkout of this repository:
+
+```bash
+cd py && pip install -e .
+```
+
+## Command Line Usage
+
+After installation the `scjson` command is available:
+
+```bash
+# Convert a single file
+scjson json path/to/machine.scxml
+
+# Convert back to SCXML
+scjson xml path/to/machine.scjson
+
+# Validate recursively
+scjson validate path/to/dir -r
+```
+
+## License
+
+All source code in this directory is released under the BSD&nbsp;1-Clause license. See `LEGAL.md` for details.
+

--- a/py/setup.py
+++ b/py/setup.py
@@ -1,9 +1,15 @@
+from pathlib import Path
 from setuptools import setup, find_packages
+
+this_dir = Path(__file__).parent
+long_description = (this_dir / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="scjson",
     version="0.1.0",
     description="Tools for converting between scjson and SCXML",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     packages=find_packages(),
     install_requires=[
         "click",
@@ -16,4 +22,5 @@ setup(
             "scjson=scjson.cli:main",
         ]
     },
+    data_files=[("", ["LEGAL.md"])],
 )


### PR DESCRIPTION
## Summary
- document the Python distribution
- add legal notice for the Python package
- include legal doc via MANIFEST
- load README for packaging metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c491e938833397e9edd77bb94be7