### PR TITLE
Add Swift library target

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -4,15 +4,21 @@ import PackageDescription
 let package = Package(
     name: "scjson-swift",
     products: [
+        .library(name: "SCJSONKit", targets: ["SCJSONKit"]),
         .executable(name: "scjson-swift", targets: ["scjson"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2")
     ],
     targets: [
+        .target(
+            name: "SCJSONKit",
+            dependencies: []
+        ),
         .executableTarget(
             name: "scjson",
             dependencies: [
+                "SCJSONKit",
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]
         ),

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,6 +1,6 @@
 # scjson Swift Package
 
-This directory contains the Swift implementation of **scjson**. The package exposes a command line tool that can convert between `.scxml` and `.scjson` and perform validation using the shared schema.
+This directory contains the Swift implementation of **scjson**. The package exposes a reusable library (`SCJSONKit`) and a command line tool that can convert between `.scxml` and `.scjson` and perform validation using the shared schema.
 
 ## Installation
 
@@ -9,6 +9,16 @@ swift build -c release
 ```
 
 After building, the `scjson` executable will be available in `.build/release`.
+
+## Library Usage
+
+Add `SCJSONKit` as a dependency in your `Package.swift` and import the models:
+
+```swift
+import SCJSONKit
+
+let doc = ScjsonDocument()
+```
 
 ## Command Line Usage
 

--- a/swift/Sources/SCJSONKit/Models.swift
+++ b/swift/Sources/SCJSONKit/Models.swift
@@ -1,0 +1,40 @@
+/*
+Agent Name: swift-lib
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+*/
+
+import Foundation
+
+/** Root scjson document model.
+ - Parameters:
+   - version: Schema version.
+   - datamodelAttribute: Datamodel handling attribute.
+ */
+public struct ScjsonDocument: Codable {
+    public var version: Int
+    public var datamodelAttribute: String
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case datamodelAttribute = "datamodel_attribute"
+    }
+
+    /** Create a new document.
+     - Parameters:
+       - version: Schema version.
+       - datamodelAttribute: Datamodel handling attribute.
+     */
+    public init(version: Int = 1, datamodelAttribute: String = "null") {
+        self.version = version
+        self.datamodelAttribute = datamodelAttribute
+    }
+}
+
+/** Assign manipulation types for the datamodel location. */
+public enum AssignType: String, Codable {
+    case replacechildren
+    case firstchild
+}

--- a/swift/Sources/scjson/main.swift
+++ b/swift/Sources/scjson/main.swift
@@ -8,6 +8,7 @@ Licensed under the BSD 1-Clause License.
 
 import Foundation
 import ArgumentParser
+import SCJSONKit
 
 /**
  Conversion utilities and CLI for SCXML <-> scjson.
@@ -159,9 +160,9 @@ extension SCJSON {
      - Returns: JSON representation.
      */
     static func xmlToJson(_ xml: String, omitEmpty: Bool = true) throws -> String {
-        let obj: [String: Any] = ["version": 1, "datamodel_attribute": "null"]
-        let jsonData = try JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted])
-        return String(data: jsonData, encoding: .utf8) ?? "{}"
+        let doc = ScjsonDocument(version: 1, datamodelAttribute: omitEmpty ? "null" : "")
+        let data = try JSONEncoder().encode(doc)
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 
     /** Convert scjson string to SCXML.
@@ -169,8 +170,9 @@ extension SCJSON {
      - Returns: SCXML representation.
      */
     static func jsonToXml(_ json: String) throws -> String {
-        _ = try JSONSerialization.jsonObject(with: Data(json.utf8))
-        return "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\"/>"
+        let data = Data(json.utf8)
+        let doc = try JSONDecoder().decode(ScjsonDocument.self, from: data)
+        return "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\" datamodel=\"\(doc.datamodelAttribute)\"/>"
     }
 
     private static func convertScxmlFile(src: URL, dest: URL?, keepEmpty: Bool, verify: Bool) throws {


### PR DESCRIPTION
## Summary
- expose SCJSONKit as a library with example models
- wire CLI target to depend on SCJSONKit
- document library usage in Swift README
- update conversion helpers to use typed models

## Testing
- `swift test`
- `python3 uber_test.py -q` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_687ae307e240833394f03f246456a372