### PR TITLE
Add attribution block to SCXMLDocumentHandler

### DIFF
--- a/py/scjson/SCXMLDocumentHandler.py
+++ b/py/scjson/SCXMLDocumentHandler.py
@@ -1,3 +1,14 @@
+"""
+Agent Name: scxml-document-handler
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+Utilities for loading, validating, and converting SCXML documents to and from
+their JSON representation.
+"""
+
 from typing import Optional, Type, Union, Any, get_args, get_origin
 from enum import Enum
 from decimal import Decimal


### PR DESCRIPTION
## Summary
- add standard attribution block to `SCXMLDocumentHandler.py`
- include short module description about SCXML conversion utilities

## Testing
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*

------
https://chatgpt.com/codex/tasks/task_e_68804f78599883338b2db9742c85d13d