### PR TITLE
Refactor runtime modules

### DIFF
--- a/py/scjson/__init__.py
+++ b/py/scjson/__init__.py
@@ -9,6 +9,15 @@ scjson conversion tools.
 """
 
 from .context import DocumentContext
+from .events import Event, EventQueue
+from .activation import ActivationRecord, TransitionSpec
 from .json_stream import JsonStreamDecoder
 
-__all__ = ["DocumentContext", "JsonStreamDecoder"]
+__all__ = [
+    "DocumentContext",
+    "JsonStreamDecoder",
+    "Event",
+    "EventQueue",
+    "ActivationRecord",
+    "TransitionSpec",
+]

--- a/py/scjson/activation.py
+++ b/py/scjson/activation.py
@@ -1,0 +1,78 @@
+"""
+Agent Name: python-activation
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+Activation record definitions for the runtime engine.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+from .pydantic import Scxml, State, ScxmlParallelType, ScxmlFinalType, History
+
+SCXMLNode = State | ScxmlParallelType | ScxmlFinalType | History | Scxml
+
+
+class ActivationStatus(str, Enum):
+    """Enumeration of activation states."""
+
+    ACTIVE = "active"
+    FINAL = "final"
+
+
+class TransitionSpec(BaseModel):
+    """Simplified representation of a transition."""
+
+    event: Optional[str] = None
+    target: List[str] = Field(default_factory=list)
+    cond: Optional[str] = None
+
+
+class ActivationRecord(BaseModel):
+    """Runtime frame for an entered state/parallel/final element."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    id: str
+    node: SCXMLNode
+    parent: Optional["ActivationRecord"] = None
+    status: ActivationStatus = ActivationStatus.ACTIVE
+    local_data: Dict[str, Any] = Field(default_factory=dict)
+    children: List["ActivationRecord"] = Field(default_factory=list)
+    transitions: List["TransitionSpec"] = Field(default_factory=list)
+
+    def mark_final(self) -> None:
+        """Flag this activation and its ancestors as final when complete."""
+        self.status = ActivationStatus.FINAL
+        if self.parent and all(c.status is ActivationStatus.FINAL for c in self.parent.children):
+            self.parent.mark_final()
+
+    def add_child(self, child: "ActivationRecord") -> None:
+        """Add ``child`` to this activation's children list.
+
+        :param child: Activation record to attach.
+        :returns: ``None``
+        """
+        self.children.append(child)
+
+    def is_active(self) -> bool:  # noqa: D401
+        """Return *True* while the activation is not finalised."""
+        return self.status is ActivationStatus.ACTIVE
+
+    def path(self) -> List["ActivationRecord"]:
+        """Return the ancestry chain from root to ``self``.
+
+        :returns: ``list`` of activations starting at the root.
+        """
+        cur: Optional["ActivationRecord"] = self
+        out: List["ActivationRecord"] = []
+        while cur:
+            out.append(cur)
+            cur = cur.parent
+        return list(reversed(out))

--- a/py/scjson/events.py
+++ b/py/scjson/events.py
@@ -1,0 +1,50 @@
+"""
+Agent Name: python-events
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+Event primitives used by the runtime engine.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Deque, Optional
+
+from pydantic import BaseModel
+
+
+class Event(BaseModel):
+    """Simple event container."""
+
+    name: str
+    data: Any | None = None
+
+
+class EventQueue:
+    """Simple FIFO for external/internal events."""
+
+    def __init__(self) -> None:
+        """Create an empty queue."""
+        self._q: Deque[Event] = deque()
+
+    def push(self, evt: Event) -> None:
+        """Append ``evt`` to the queue.
+
+        :param evt: ``Event`` instance to enqueue.
+        :returns: ``None``
+        """
+        self._q.append(evt)
+
+    def pop(self) -> Optional[Event]:
+        """Remove and return the next event if available.
+
+        :returns: The next ``Event`` or ``None`` when empty.
+        """
+        return self._q.popleft() if self._q else None
+
+    def __bool__(self) -> bool:
+        """Return ``True`` if any events are queued."""
+        return bool(self._q)


### PR DESCRIPTION
## Summary
- split Event and EventQueue into new `events` module
- split ActivationRecord and helpers into new `activation` module
- keep DocumentContext in `context` but import the new pieces
- expose runtime classes from package init

## Testing
- `poetry install`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68805cbd6e288333aab85840813dcdbb