### PR TITLE
Enable offline Maven build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ swift/.build/
 csharp/**/bin/
 csharp/**/obj/
 csharp/tmp*/
+java/lib/*.jar

--- a/codex/startup.sh
+++ b/codex/startup.sh
@@ -35,7 +35,13 @@ if [ ! -f ~/.m2/settings.xml ]; then
 EOF
 fi
 
-cd java && mvn clean install -DskipTests -B && cd ..
+if [ ! -f java/lib/commons-scxml-0.9.jar ]; then
+  curl -L -o java/lib/commons-scxml-0.9.jar \
+    https://repo1.maven.org/maven2/commons-scxml/commons-scxml/0.9/commons-scxml-0.9.jar
+fi
+
+cd java && mvn -B -DskipTests dependency:go-offline && \
+    mvn clean install -DskipTests -o -B && cd ..
 cd rust && cargo clean && cargo fetch && cargo build --locked && cd ..
 cd swift && swift package resolve && swift build && cd ..
 cd go && go mod verify && go mod download && go build -mod=readonly && cd ..

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,8 +32,14 @@
             <artifactId>picocli</artifactId>
             <version>4.7.5</version>
         </dependency>
-        <!-- Optional: SCXML parsing and execution (Apache Commons)
-             Dependency removed pending artifact availability -->
+        <!-- Optional: SCXML parsing and execution (Apache Commons) -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-scxml</artifactId>
+            <version>0.9</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/commons-scxml-0.9.jar</systemPath>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/java/src/test/java/com/softoboros/ScjsonCliTest.java
+++ b/java/src/test/java/com/softoboros/ScjsonCliTest.java
@@ -128,4 +128,13 @@ public class ScjsonCliTest {
                 .execute(jsonDir.toString(), "-r", "-v");
         assertEquals(0, v2);
     }
+
+    /**
+     * Verify that the Apache Commons SCXML library is on the classpath.
+     */
+    @Test
+    void testCommonsScxmlAvailable() {
+        org.apache.commons.scxml.model.SCXML machine = new org.apache.commons.scxml.model.SCXML();
+        assertNotNull(machine);
+    }
 }


### PR DESCRIPTION
## Summary
- fetch Apache Commons SCXML jar during startup instead of bundling it
- ignore local `java/lib/*.jar` artifacts
- update startup script with correct URL for the jar

## Testing
- `cd py && pip install -q -r requirements.txt && pytest -q`
- `cd java && mvn test`
- `cd go && go test ./...`
- `cd js && npm test --silent`
- `cd ruby && bundle install && bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68805b942028833380c7d676590a865b