### PR TITLE
Fix offline mvn build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ js/node_modules
 # Rust build artifacts
 rust/target/
 go/go
+go/scjson
 java/target/
+java/commons-scxml/
 swift/.build/
 csharp/**/bin/
 csharp/**/obj/

--- a/codex/startup.sh
+++ b/codex/startup.sh
@@ -1,3 +1,10 @@
+#!/bin/bash
+# Agent Name: startup-script
+#
+# Part of the scjson project.
+# Developed by Softoboros Technology Inc.
+# Licensed under the BSD 1-Clause License.
+
 apt update && apt install -y nano maven gradle lua5.4 luarocks dotnet-sdk-8.0
 unset NPM_CONFIG_HTTP_PROXY
 unset NPM_CONFIG_HTTPS_PROXY
@@ -43,7 +50,8 @@ cd java \
   && git checkout tags/commons-scxml2-2.0-M1 -b scxml-2.0-M1 \
   && mvn clean install -DskipTests -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 \
   && cd ..
-  && mvn clean install -DskipTests -B -Dmaven.compiler.source=8 -Dmaven.compiler.target=8\
+  && mvn clean install -DskipTests -B -Dmaven.compiler.source=8 -Dmaven.compiler.target=8 \
+  && mvn -q -DskipTests dependency:go-offline \
   && cd ..
 cd rust && cargo clean && cargo fetch && cargo build --locked && cd ..
 cd swift && swift package resolve && swift build && cd ..

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -54,17 +54,14 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <mainClass>com.softobros.ScjsonCli</mainClass>
-                </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>2.16</version>
             </plugin>
         </plugins>
     </build>

--- a/java/src/main/java/com/softoboros/ScxmlRunner.java
+++ b/java/src/main/java/com/softoboros/ScxmlRunner.java
@@ -14,7 +14,7 @@ import org.apache.commons.scxml2.env.SimpleDispatcher;
 import org.apache.commons.scxml2.env.SimpleErrorReporter;
 import org.apache.commons.scxml2.env.SimpleSCXMLListener;
 import org.apache.commons.scxml2.env.jexl.JexlEvaluator;
-import org.apache.commons.scxml2.env.jexl.JexlUtils;
+import org.apache.commons.scxml2.env.jexl.JexlContext;
 import org.apache.commons.scxml2.io.SCXMLReader;
 import org.apache.commons.scxml2.model.EnterableState;
 import org.apache.commons.scxml2.model.SCXML;
@@ -100,9 +100,10 @@ public final class ScxmlRunner {
         }
 
         ExecutionTrace trace = new ExecutionTrace();
-        SCXMLExecutor exec = new SCXMLExecutor(new JexlEvaluator(), new SimpleDispatcher(), new SimpleErrorReporter());
+        JexlEvaluator evaluator = new JexlEvaluator();
+        SCXMLExecutor exec = new SCXMLExecutor(evaluator, new SimpleDispatcher(), new SimpleErrorReporter());
         exec.setStateMachine(scxml);
-        exec.setRootContext(JexlUtils.newContext(null));
+        exec.setRootContext(new JexlContext());
         exec.addListener(scxml, new SimpleSCXMLListener() {
             @Override
             public void onEntry(EnterableState state) {


### PR DESCRIPTION
## Summary
- support offline Java build
- fix Jexl context usage
- ignore generated Java libs and Go binary

## Testing
- `mvn -q test` *(fails: Unable to generate classpath)*

------
https://chatgpt.com/codex/tasks/task_e_6880fac23c8c83338147530fd700d27b