### PR TITLE
Add Java run command with event logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ Build the module with:
 cd java && mvn clean install -DskipTests -B && cd ..
 ```
 #### Running SCXML documents
-Use `ScxmlRunner` to execute state machines and capture traces. Example:
+You can execute a state machine using the CLI:
 ```bash
-java com.softoboros.ScxmlRunner examples/example.scxml examples/events.json trace.json
+java -jar target/scjson.jar run examples/example.scxml -e examples/events.json -o trace.json
 ```
-This command requires the Apache Commons SCXML library. Ensure Maven can download dependencies or has them cached locally.
+This uses `ScxmlRunner` under the hood and requires the Apache Commons SCXML library. Ensure Maven can download dependencies or has them cached locally.
 ### Package Repostory Availability
 pypi: [https://pypi.org/project/scjson/]
 ```bash

--- a/java/README.md
+++ b/java/README.md
@@ -14,6 +14,7 @@ cd java && mvn package -DskipTests
 java -jar target/scjson.jar json path/to/machine.scxml
 java -jar target/scjson.jar xml path/to/machine.scjson
 java -jar target/scjson.jar validate path/to/dir -r
+java -jar target/scjson.jar run path/to/machine.scxml -e events.json -o trace.json
 ```
 
 All source code in this directory is released under the BSD\u00A01-Clause license. See `LICENSE` and `LEGAL.md` for details.

--- a/java/src/main/java/com/softoboros/RunCommand.java
+++ b/java/src/main/java/com/softoboros/RunCommand.java
@@ -1,0 +1,51 @@
+/**
+ * Agent Name: run-command
+ *
+ * Part of the scjson project.
+ * Developed by Softoboros Technology Inc.
+ * Licensed under the BSD 1-Clause License.
+ */
+package com.softobros;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Execute an SCXML document and optionally write an execution trace.
+ */
+@Command(name = "run", description = "Execute an SCXML document")
+public class RunCommand implements java.util.concurrent.Callable<Integer> {
+
+    /** SCXML document to execute. */
+    @Parameters(paramLabel = "SCXML", description = "SCXML file to execute")
+    private File scxmlFile;
+
+    /** Optional JSON file containing input events. */
+    @Option(names = {"-e", "--events"}, description = "JSON file of events")
+    private File eventsFile;
+
+    /** Optional output file for the execution trace. */
+    @Option(names = {"-o", "--output"}, description = "Output trace file")
+    private File outputFile;
+
+    @Override
+    public Integer call() throws Exception {
+        List<ScxmlRunner.Event> events = new ArrayList<>();
+        if (eventsFile != null) {
+            events = ScxmlRunner.loadEvents(eventsFile);
+        }
+        ScxmlRunner.ExecutionTrace trace = ScxmlRunner.run(scxmlFile, events);
+        if (outputFile != null) {
+            ScxmlRunner.writeTrace(trace, outputFile);
+        } else {
+            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            mapper.writerWithDefaultPrettyPrinter().writeValue(System.out, trace);
+        }
+        return 0;
+    }
+}

--- a/java/src/main/java/com/softoboros/ScjsonCli.java
+++ b/java/src/main/java/com/softoboros/ScjsonCli.java
@@ -36,6 +36,7 @@ public class ScjsonCli implements Runnable {
                 .addSubcommand("to-json", new ScxmlToScjson())
                 .addSubcommand("to-xml", new ScjsonToScxml())
                 .addSubcommand("validate", new ValidateCommand())
+                .addSubcommand("run", new RunCommand())
                 .execute(args);
         System.exit(exitCode);
     }

--- a/java/src/test/java/com/softoboros/RunCommandTest.java
+++ b/java/src/test/java/com/softoboros/RunCommandTest.java
@@ -1,0 +1,45 @@
+/**
+ * Agent Name: run-command-test
+ *
+ * Part of the scjson project.
+ * Developed by Softoboros Technology Inc.
+ * Licensed under the BSD 1-Clause License.
+ */
+package com.softobros;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verify the run command produces an execution trace.
+ */
+public class RunCommandTest {
+
+    private static final String SCXML = "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\" version=\"1.0\" initial=\"start\">" +
+            "<state id=\"start\"><transition event=\"go\" target=\"end\"/></state>" +
+            "<final id=\"end\"/></scxml>";
+
+    private static final String EVENTS = "[{\"name\": \"go\"}]";
+
+    @Test
+    void testRunProducesLog(@TempDir Path tmp) throws Exception {
+        Path xml = tmp.resolve("machine.scxml");
+        Files.writeString(xml, SCXML);
+        Path evts = tmp.resolve("events.json");
+        Files.writeString(evts, EVENTS);
+        Path log = tmp.resolve("trace.json");
+
+        int exit = new CommandLine(new RunCommand()).execute(
+                xml.toString(), "-e", evts.toString(), "-o", log.toString());
+        assertEquals(0, exit);
+        assertTrue(Files.exists(log));
+        String content = Files.readString(log);
+        assertTrue(content.contains("enter"), "Trace should contain entries");
+    }
+}


### PR DESCRIPTION
## Summary
- add `run` subcommand to Java CLI to execute SCXML docs
- log execution trace to file when `-o/--output` is specified
- document usage of new command in README files
- test running with events via new RunCommandTest

## Testing
- `cd java && mvn -q test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68813604edb08333aff19b4743042ee7