### PR TITLE
Add event log file to CLI run command

### DIFF
--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -164,7 +164,9 @@ def test_run_command_scjson(tmp_path):
     runner = CliRunner()
     result = runner.invoke(main, ["run", "-I", str(json_path), "-o", str(tmp_path)])
     assert result.exit_code == 0
-    assert "[microstep] consumed event: start" in result.output
+    log_path = tmp_path / "events.log"
+    assert log_path.exists()
+    assert "[microstep] consumed event: start" in log_path.read_text()
 
 
 def test_run_command_scxml(tmp_path):
@@ -174,7 +176,9 @@ def test_run_command_scxml(tmp_path):
     runner = CliRunner()
     result = runner.invoke(main, ["run", "-I", str(xml_path), "--xml", "-o", str(tmp_path)])
     assert result.exit_code == 0
-    assert "[microstep] consumed event: start" in result.output
+    log_path = tmp_path / "events.log"
+    assert log_path.exists()
+    assert "[microstep] consumed event: start" in log_path.read_text()
 
 
 


### PR DESCRIPTION
## Summary
- add ability to log events when running the demo engine
- update tests for new behaviour

## Testing
- `cd py && poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688136d8a0f083339ab25a9ca59b2676