### PR TITLE
Add attribution to Python entrypoint

### DIFF
--- a/py/scjson/__main__.py
+++ b/py/scjson/__main__.py
@@ -1,3 +1,11 @@
+"""
+Agent Name: python-entrypoint
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+"""
+
 from .cli import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add missing attribution docstring for python entrypoint

## Testing
- `poetry install` *(fails: all attempts to connect to pypi.org failed)*

------
https://chatgpt.com/codex/tasks/task_e_68814ae48a208333bbc392ae1cdb9e39