### PR TITLE
Support skipping unknown SCXML elements

### DIFF
--- a/py/scjson/SCXMLDocumentHandler.py
+++ b/py/scjson/SCXMLDocumentHandler.py
@@ -6,7 +6,11 @@ Developed by Softoboros Technology Inc.
 Licensed under the BSD 1-Clause License.
 
 Utilities for loading, validating, and converting SCXML documents to and from
-their JSON representation.
+their JSON representation.  The underlying :class:`~xsdata.formats.dataclass.parsers.XmlParser`
+can enforce strict schema checking.  By default unknown XML elements raise an
+exception; set ``fail_on_unknown_properties=False`` when instantiating
+:class:`SCXMLDocumentHandler` to ignore and skip unrecognised fields during
+parsing.
 """
 
 from typing import Optional, Type, Union, Any, get_args, get_origin, ForwardRef
@@ -17,6 +21,7 @@ import json
 from dataclasses import asdict, fields, is_dataclass
 from xsdata.formats.dataclass.serializers.config import SerializerConfig
 from xsdata.formats.dataclass.parsers import XmlParser
+from xsdata.formats.dataclass.parsers.config import ParserConfig
 from xsdata.formats.dataclass.serializers import XmlSerializer
 from xsdata.formats.dataclass.models.generics import AnyElement
 from . import dataclasses as dataclasses_module
@@ -29,10 +34,33 @@ class SCXMLDocumentHandler:
         schema_path: Optional[str] = None,
         pretty: bool = True,
         omit_empty: bool = True,
+        fail_on_unknown_properties: bool = True,
     ) -> None:
+        """Create a new document handler.
+
+        Parameters
+        ----------
+        model_class: Type, optional
+            Root dataclass for the SCXML schema.
+        schema_path: str | None, optional
+            Optional path to an XML Schema document for validation.
+        pretty: bool, optional
+            Pretty-print output when serialising.
+        omit_empty: bool, optional
+            Drop ``None`` or empty containers from JSON output.
+        fail_on_unknown_properties: bool, optional
+            When ``True`` (default) unexpected XML elements raise an exception
+            during parsing.  Set ``False`` to ignore them.
+
+        Returns
+        -------
+        None
+        """
         self.model_class = model_class
         self.schema_path = schema_path
-        self.parser = XmlParser()
+        self.parser = XmlParser(
+            config=ParserConfig(fail_on_unknown_properties=fail_on_unknown_properties)
+        )
         self.serializer = XmlSerializer(
             config=SerializerConfig(
                 pretty_print=pretty, encoding="utf-8", xml_declaration=True

--- a/py/scjson/cli.py
+++ b/py/scjson/cli.py
@@ -108,9 +108,22 @@ def xml(path: Path, output: Path | None, recursive: bool, verify: bool, keep_emp
 @click.option("--recursive", "-r", is_flag=True, default=False, help="Recurse into subdirectories when PATH is a directory")
 @click.option("--verify", "-v", is_flag=True, default=False, help="Verify conversion without writing output")
 @click.option("--keep-empty", is_flag=True, default=False, help="Keep null or empty items when producing JSON")
-def json(path: Path, output: Path | None, recursive: bool, verify: bool, keep_empty: bool):
+@click.option(
+    "--fail-unknown/--skip-unknown",
+    "fail_unknown",
+    default=True,
+    help="Fail on unknown XML elements when converting",
+)
+def json(
+    path: Path,
+    output: Path | None,
+    recursive: bool,
+    verify: bool,
+    keep_empty: bool,
+    fail_unknown: bool,
+):
     """Convert a single SCXML file or all SCXML files in a directory."""
-    handler = SCXMLDocumentHandler(omit_empty=not keep_empty)
+    handler = SCXMLDocumentHandler(omit_empty=not keep_empty, fail_on_unknown_properties=fail_unknown)
 
     def convert_file(src: Path, dest: Path | None):
         try:

--- a/py/tests/test_engine.py
+++ b/py/tests/test_engine.py
@@ -9,6 +9,7 @@ Licensed under the BSD 1-Clause License.
 from decimal import Decimal
 from scjson.pydantic import Scxml, State, Transition, Datamodel, Data
 from scjson.context import DocumentContext
+from scjson.SCXMLDocumentHandler import SCXMLDocumentHandler
 
 
 def _make_doc():
@@ -263,3 +264,16 @@ def test_history_state_restore():
     ctx.enqueue("back")
     ctx.microstep()
     assert "p" in ctx.configuration and "s2" in ctx.configuration
+
+
+def test_xml_skip_unknown(tmp_path):
+    """Unknown elements are ignored when configured."""
+    xml = (
+        "<scxml xmlns='http://www.w3.org/2005/07/scxml'>"
+        "<state id='a'/><bogus/></scxml>"
+    )
+    path = tmp_path / "bad.scxml"
+    path.write_text(xml)
+    handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+    json_str = handler.xml_to_json(xml)
+    assert "bogus" not in json_str

--- a/py/uber_test.py
+++ b/py/uber_test.py
@@ -126,7 +126,7 @@ def main(out_dir: str | Path = "uber_out", language: str | None = None) -> None:
         Limit the run to a single language key from :data:`LANG_CMDS`.
     """
 
-    handler = SCXMLDocumentHandler()
+    handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
     scxml_files = sorted(TUTORIAL.rglob("*.scxml"))
     canonical = _canonical_json(scxml_files, handler)
     scxml_files = list(canonical.keys())
@@ -155,8 +155,11 @@ def main(out_dir: str | Path = "uber_out", language: str | None = None) -> None:
         json_dir.mkdir(parents=True, exist_ok=True)
         xml_dir.mkdir(parents=True, exist_ok=True)
         try:
+            json_args = ["json", str(TUTORIAL), "-o", str(json_dir), "-r"]
+            if lang == "python":
+                json_args.append("--skip-unknown")
             subprocess.run(
-                cmd + ["json", str(TUTORIAL), "-o", str(json_dir), "-r"],
+                cmd + json_args,
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- configure `SCXMLDocumentHandler` parser to optionally ignore unknown elements
- expose this behaviour on the CLI with `--fail-unknown/--skip-unknown`
- document parser behaviour in module docstring
- test skipping of unknown XML properties
- ignore unknown properties in `uber_test`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882617e559c83339b9c729819432cd0