### PR TITLE
Improve JS empty element handling

### DIFF
--- a/js/tests/converters.test.js
+++ b/js/tests/converters.test.js
@@ -70,3 +70,27 @@ test('assign and send defaults are applied', () => {
   expect(entry.send[0].type_value).toBe('scxml');
   expect(entry.send[0].delay).toBe('0s');
 });
+
+/**
+ * Ensure empty ``else`` blocks are preserved.
+ */
+test('empty else becomes object', () => {
+  const xml =
+    '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><onentry><if cond="true"><else/></if></onentry></state></scxml>';
+  const obj = JSON.parse(xmlToJson(xml));
+  const entry = obj.state[0].onentry[0];
+  expect(entry.if_value[0]).toHaveProperty('else_value');
+  expect(entry.if_value[0].else_value).toEqual({});
+});
+
+/**
+ * Preserve empty ``final`` elements nested in other actions.
+ */
+test('empty final element survives cleanup', () => {
+  const xml =
+    '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><onentry><assign location="x"><scxml><final/></scxml></assign></onentry></state></scxml>';
+  const obj = JSON.parse(xmlToJson(xml));
+  const assign = obj.state[0].onentry[0].assign[0];
+  expect(assign.content[0]).toHaveProperty('final');
+  expect(assign.content[0].final).toEqual([{}]);
+});


### PR DESCRIPTION
## Summary
- ensure `removeEmpty` keeps empty `final` elements
- propagate key context when pruning arrays
- convert nested `<scxml>` `final` blocks to objects before cleaning
- reapply cleanup both before and after validation
- test that empty `<final/>` survives round trip

## Testing
- `npm test --silent --prefix js`
- `pytest -q`
- `SCJSON_UBER_DEBUG=1 python py/uber_test.py -l javascript` *(fails: javascript encountered 167 mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68829ac822288333977732b697b998a8