### PR TITLE
Improve JS root transition handling

### DIFF
--- a/js/tests/converters.test.js
+++ b/js/tests/converters.test.js
@@ -70,3 +70,38 @@ test('assign and send defaults are applied', () => {
   expect(entry.send[0].type_value).toBe('scxml');
   expect(entry.send[0].delay).toBe('0s');
 });
+
+/**
+ * Ensure empty ``else`` blocks are preserved.
+ */
+test('empty else becomes object', () => {
+  const xml =
+    '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><onentry><if cond="true"><else/></if></onentry></state></scxml>';
+  const obj = JSON.parse(xmlToJson(xml));
+  const entry = obj.state[0].onentry[0];
+  expect(entry.if_value[0]).toHaveProperty('else_value');
+  expect(entry.if_value[0].else_value).toEqual({});
+});
+
+/**
+ * Preserve empty ``final`` elements nested in other actions.
+ */
+test('empty final element survives cleanup', () => {
+  const xml =
+    '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><onentry><assign location="x"><scxml><final/></scxml></assign></onentry></state></scxml>';
+  const obj = JSON.parse(xmlToJson(xml));
+  const assign = obj.state[0].onentry[0].assign[0];
+  expect(assign.content[0]).toHaveProperty('final');
+  expect(assign.content[0].final).toEqual([{}]);
+});
+
+/**
+ * Root level transitions are ignored like the Python converter.
+ */
+test('root transitions are dropped', () => {
+  const xml =
+    '<scxml xmlns="http://www.w3.org/2005/07/scxml"><transition target="s"/><state id="s"/></scxml>';
+  const obj = JSON.parse(xmlToJson(xml));
+  expect(obj).not.toHaveProperty('transition');
+  expect(obj.state[0].id).toBe('s');
+});

--- a/py/uber_test.py
+++ b/py/uber_test.py
@@ -15,6 +15,8 @@ directory by default.
 
 from __future__ import annotations
 
+from deepdiff import DeepDiff
+
 import json
 import shutil
 import subprocess
@@ -86,6 +88,31 @@ def _available(cmd: list[str], env: dict[str, str] | None = None) -> bool:
         return True
     except Exception:
         return False
+
+
+def _diff_report(expected: dict, actual: dict) -> str:
+    """Create a human-readable diff between two dictionaries.
+
+    Parameters
+    ----------
+    expected: dict
+        Canonical structure produced by the Python implementation.
+    actual: dict
+        Structure produced by the language under test.
+
+    Returns
+    -------
+    str
+        Diff string suitable for console output.
+    """
+
+    diff = DeepDiff(
+        expected,
+        actual,
+        verbose_level=1,
+        ignore_numeric_type_changes=True,
+    )
+    return diff.pretty()
 
 
 def _canonical_json(files: list[Path], handler: SCXMLDocumentHandler) -> dict[Path, dict]:
@@ -180,6 +207,7 @@ def main(out_dir: str | Path = "uber_out", language: str | None = None) -> None:
                     continue
                 if data != canonical[src]:
                     print(f"{lang} JSON mismatch: {rel}")
+                    print(_diff_report(canonical[src], data))
                     errors += 1
             subprocess.run(
                 cmd + ["xml", str(json_dir), "-o", str(xml_dir), "-r"],
@@ -203,6 +231,7 @@ def main(out_dir: str | Path = "uber_out", language: str | None = None) -> None:
                     continue
                 if parsed != canonical[src]:
                     print(f"{lang} XML mismatch: {rel}")
+                    print(_diff_report(canonical[src], parsed))
                     errors += 1
             if errors:
                 print(f"{lang} encountered {errors} mismatches")


### PR DESCRIPTION
## Summary
- prune root-level transitions in JS converter to match Python
- normalize version output to `1.0`
- ignore numeric type changes in the uber test diff
- test dropping of root transitions
- allow script blocks to emit plain text rather than `<content>` wrappers

## Testing
- `npm test --silent --prefix js`
- `pytest -q`
- `SCJSON_UBER_DEBUG=1 python py/uber_test.py -l javascript` *(fails: javascript encountered 141 mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68829ac822288333977732b697b998a8