### PR TITLE
Add Rust XML/JSON converter tests

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,9 +6,9 @@
 //!
 //! Library providing basic SCXML <-> scjson conversion.
 
-use serde_json::{Number, Value};
+use serde_json::{Map, Number, Value};
 use thiserror::Error;
-use xmltree::Element;
+use xmltree::{Element, XMLNode};
 use xmltree::Error as XmlWriteError;
 
 /// Errors produced by conversion routines.
@@ -24,6 +24,256 @@ pub enum ScjsonError {
     Unsupported,
 }
 
+fn append_child(map: &mut Map<String, Value>, key: &str, val: Value) {
+    use serde_json::Value::{Array};
+    match map.get_mut(key) {
+        Some(Array(arr)) => arr.push(val),
+        Some(other) => {
+            let old = other.take();
+            *other = Array(vec![old, val]);
+        }
+        None => {
+            map.insert(key.to_string(), Array(vec![val]));
+        }
+    }
+}
+
+fn element_to_map(elem: &Element) -> Map<String, Value> {
+    let mut map = Map::new();
+    for (k, v) in &elem.attributes {
+        match (elem.name.as_str(), k.as_str()) {
+            ("transition", "target") => {
+                let vals: Vec<Value> = v
+                    .split_whitespace()
+                    .map(|s| Value::String(s.to_string()))
+                    .collect();
+                map.insert("target".into(), Value::Array(vals));
+            }
+            (_, "initial") => {
+                let vals: Vec<Value> = v
+                    .split_whitespace()
+                    .map(|s| Value::String(s.to_string()))
+                    .collect();
+                map.insert("initial_attribute".into(), Value::Array(vals));
+            }
+            (_, "version") => {
+                if let Ok(n) = v.parse::<f64>() {
+                    if (n.fract() - 0.0).abs() < f64::EPSILON {
+                        map.insert("version".into(), Value::Number(Number::from(n as i64)));
+                    } else {
+                        map.insert("version".into(), Value::Number(Number::from_f64(n).unwrap()));
+                    }
+                } else {
+                    map.insert("version".into(), Value::String(v.clone()));
+                }
+            }
+            (_, "datamodel") => {
+                map.insert("datamodel_attribute".into(), Value::String(v.clone()));
+            }
+            (_, "type") => {
+                map.insert("type_value".into(), Value::String(v.clone()));
+            }
+            ("send", "delay") => {
+                map.insert("delay".into(), Value::String(v.clone()));
+            }
+            ("send", "event") => {
+                map.insert("event_attribute".into(), Value::String(v.clone()));
+            }
+            (_, "xmlns") => {}
+            _ => {
+                map.insert(format!("{}_attribute", k), Value::String(v.clone()));
+            }
+        }
+    }
+
+    if elem.name == "assign" && !map.contains_key("type_value") {
+        map.insert("type_value".to_string(), Value::String("replacechildren".into()));
+    }
+    if elem.name == "send" {
+        map.entry("type_value".to_string())
+            .or_insert_with(|| Value::String("scxml".into()));
+        map.entry("delay".to_string())
+            .or_insert_with(|| Value::String("0s".into()));
+    }
+
+    let mut text_items = Vec::new();
+    for child in &elem.children {
+        match child {
+            XMLNode::Element(e) => {
+                let key = match e.name.as_str() {
+                    "if" => "if_value",
+                    "else" => "else_value",
+                    name => name,
+                };
+                let child_map = element_to_map(e);
+                let target_key = if e.name == "scxml" && elem.name != "scxml" {
+                    "content"
+                } else if elem.name == "content" && e.name == "scxml" {
+                    "content"
+                } else {
+                    key
+                };
+                append_child(&mut map, target_key, Value::Object(child_map));
+            }
+            XMLNode::Text(t) => {
+                let trimmed = t.trim();
+                if !trimmed.is_empty() {
+                    text_items.push(Value::String(trimmed.to_string()));
+                }
+            }
+            _ => {}
+        }
+    }
+    if !text_items.is_empty() {
+        for item in text_items {
+            append_child(&mut map, "content", item);
+        }
+    }
+
+    if elem.name == "scxml" {
+        if let Some(v) = map.get("version") {
+            if let Some(s) = v.as_str() {
+                if let Ok(n) = s.parse::<f64>() {
+                    if (n.fract() - 0.0).abs() < f64::EPSILON {
+                        map.insert("version".into(), Value::Number(Number::from(n as i64)));
+                    } else {
+                        map.insert("version".into(), Value::Number(Number::from_f64(n).unwrap()));
+                    }
+                }
+            }
+        } else {
+            map.insert("version".into(), Value::Number(Number::from(1)));
+        }
+        map.entry("datamodel_attribute".to_string())
+            .or_insert_with(|| Value::String("null".into()));
+    }
+    map
+}
+
+fn join_tokens(v: &Value) -> Option<String> {
+    match v {
+        Value::Array(arr) => {
+            let parts: Vec<String> = arr
+                .iter()
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect();
+            Some(parts.join(" "))
+        }
+        Value::String(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn map_to_element(name: &str, map: &Map<String, Value>) -> Element {
+    if name == "scxml" && map.len() == 1 {
+        if let Some(Value::Array(arr)) = map.get("content") {
+            if arr.len() == 1 {
+                if let Some(Value::Object(obj)) = arr.get(0) {
+                    return map_to_element("scxml", obj);
+                }
+            }
+        }
+    }
+    let mut elem = Element::new(name);
+    if name == "scxml" {
+        elem.attributes.insert(
+            "xmlns".into(),
+            "http://www.w3.org/2005/07/scxml".into(),
+        );
+    }
+    for (k, v) in map {
+        if k == "content" {
+            if let Value::Array(arr) = v {
+                if name == "invoke" {
+                    let mut c_elem = Element::new("content");
+                    for item in arr {
+                        match item {
+                            Value::String(s) => c_elem.children.push(XMLNode::Text(s.clone())),
+                            Value::Object(obj) => {
+                                let child = map_to_element("scxml", obj);
+                                c_elem.children.push(XMLNode::Element(child));
+                            }
+                            _ => {}
+                        }
+                    }
+                    elem.children.push(XMLNode::Element(c_elem));
+                } else if name == "script" {
+                    for item in arr {
+                        if let Value::String(s) = item {
+                            elem.children.push(XMLNode::Text(s.clone()));
+                        }
+                    }
+                } else {
+                    for item in arr {
+                        match item {
+                            Value::String(s) => elem.children.push(XMLNode::Text(s.clone())),
+                            Value::Object(obj) => {
+                                let child = map_to_element("scxml", obj);
+                                elem.children.push(XMLNode::Element(child));
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+        if k.ends_with("_attribute") {
+            let attr = k.trim_end_matches("_attribute");
+            if let Some(val) = join_tokens(v) {
+                elem.attributes.insert(attr.into(), val);
+            }
+            continue;
+        }
+        if k == "event_attribute" {
+            if let Some(val) = join_tokens(v) {
+                elem.attributes.insert("event".into(), val);
+            }
+            continue;
+        }
+        if k == "type_value" || k == "delay" || (name == "transition" && k == "target") {
+            if let Some(val) = join_tokens(v) {
+                let attr = if k == "type_value" { "type" } else { k };
+                elem.attributes.insert(attr.into(), val);
+            }
+            continue;
+        }
+        match v {
+            Value::Array(arr) => {
+                let child_name = match k.as_str() {
+                    "if_value" => "if",
+                    "else_value" => "else",
+                    other => other,
+                };
+                for item in arr {
+                    if let Value::Object(obj) = item {
+                        let child = map_to_element(child_name, obj);
+                        elem.children.push(XMLNode::Element(child));
+                    } else if let Value::String(text) = item {
+                        elem.children.push(XMLNode::Element(map_to_element(child_name, &Map::new())));
+                        elem.children.push(XMLNode::Text(text.clone()));
+                    }
+                }
+            }
+            Value::String(s) => {
+                if k == "version" {
+                    elem.attributes.insert("version".into(), s.clone());
+                } else {
+                    elem.children.push(XMLNode::Element(map_to_element(k, &Map::new())));
+                    elem.children.push(XMLNode::Text(s.clone()));
+                }
+            }
+            Value::Number(n) => {
+                if k == "version" {
+                    elem.attributes.insert("version".into(), n.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    elem
+}
+
 /// Convert an SCXML string to scjson.
 ///
 /// # Parameters
@@ -37,27 +287,7 @@ pub fn xml_to_json(xml: &str, omit_empty: bool) -> Result<String, ScjsonError> {
     if root.name != "scxml" {
         return Err(ScjsonError::Unsupported);
     }
-    let version = root
-        .attributes
-        .get("version")
-        .and_then(|v| v.parse::<f64>().ok())
-        .unwrap_or(1.0);
-    let datamodel = root
-        .attributes
-        .get("datamodel")
-        .map(|s| s.as_str())
-        .unwrap_or("null");
-    let mut obj = serde_json::Map::new();
-    let ver_value = if (version.fract() - 0.0).abs() < f64::EPSILON {
-        Value::Number(Number::from(version as i64))
-    } else {
-        Value::Number(Number::from_f64(version).unwrap())
-    };
-    obj.insert("version".into(), ver_value);
-    obj.insert(
-        "datamodel_attribute".into(),
-        Value::String(datamodel.to_string()),
-    );
+    let obj = element_to_map(&root);
     let value = Value::Object(obj);
     if omit_empty {
         Ok(serde_json::to_string_pretty(&value)?)
@@ -76,19 +306,7 @@ pub fn xml_to_json(xml: &str, omit_empty: bool) -> Result<String, ScjsonError> {
 pub fn json_to_xml(json_str: &str) -> Result<String, ScjsonError> {
     let v: Value = serde_json::from_str(json_str)?;
     let obj = v.as_object().ok_or(ScjsonError::Unsupported)?;
-    let version = obj.get("version").and_then(|v| v.as_f64()).unwrap_or(1.0);
-    let datamodel = obj
-        .get("datamodel_attribute")
-        .and_then(|v| v.as_str())
-        .unwrap_or("null");
-
-    let mut root = Element::new("scxml");
-    root.attributes
-        .insert("xmlns".into(), "http://www.w3.org/2005/07/scxml".into());
-    root.attributes
-        .insert("version".into(), version.to_string());
-    root.attributes
-        .insert("datamodel".into(), datamodel.to_string());
+    let root = map_to_element("scxml", obj);
     let mut out = Vec::new();
     root.write(&mut out)?;
     Ok(String::from_utf8(out).unwrap())

--- a/rust/tests/converters.rs
+++ b/rust/tests/converters.rs
@@ -1,0 +1,73 @@
+//! Agent Name: rust-converters-tests
+//!
+//! Part of the scjson project.
+//! Developed by Softoboros Technology Inc.
+//! Licensed under the BSD 1-Clause License.
+
+use scjson::{xml_to_json, json_to_xml};
+use serde_json::Value;
+
+fn round_trip(xml: &str) -> Value {
+    let json = xml_to_json(xml, true).unwrap();
+    let xml_rt = json_to_xml(&json).unwrap();
+    let json_rt = xml_to_json(&xml_rt, true).unwrap();
+    serde_json::from_str(&json_rt).unwrap()
+}
+
+#[test]
+fn script_becomes_object() {
+    let xml = "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\"><script>foo</script></scxml>";
+    let obj: Value = serde_json::from_str(&xml_to_json(xml, true).unwrap()).unwrap();
+    assert!(obj.get("script").is_some());
+    assert_eq!(obj["script"][0]["content"][0], "foo");
+    let rt = round_trip(xml);
+    assert_eq!(rt, obj);
+}
+
+#[test]
+fn transition_targets_split() {
+    let xml = "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\"><state id=\"s1\"><transition target=\"a b\"/></state></scxml>";
+    let obj: Value = serde_json::from_str(&xml_to_json(xml, true).unwrap()).unwrap();
+    let trans = &obj["state"][0]["transition"][0];
+    assert_eq!(trans["target"], serde_json::json!(["a", "b"]));
+    let rt = round_trip(xml);
+    assert_eq!(rt, obj);
+}
+
+#[test]
+fn invoke_nested_scxml() {
+    let xml = "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\"><state id=\"s\"><invoke><content><scxml><state id=\"i\"/></scxml></content></invoke></state></scxml>";
+    let obj: Value = serde_json::from_str(&xml_to_json(xml, true).unwrap()).unwrap();
+    assert!(obj["state"][0]["invoke"][0]["content"][0]["content"][0].get("state").is_some());
+    let rt = round_trip(xml);
+    assert_eq!(rt, obj);
+}
+
+#[test]
+fn assign_send_defaults() {
+    let xml = "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\"><state id=\"s\"><onentry><assign location=\"foo\" expr=\"1\"/><send event=\"e\"/></onentry></state></scxml>";
+    let obj: Value = serde_json::from_str(&xml_to_json(xml, true).unwrap()).unwrap();
+    let entry = &obj["state"][0]["onentry"][0];
+    assert_eq!(entry["assign"][0]["type_value"], "replacechildren");
+    assert_eq!(entry["send"][0]["type_value"], "scxml");
+    assert_eq!(entry["send"][0]["delay"], "0s");
+    let rt = round_trip(xml);
+    assert_eq!(rt, obj);
+}
+
+#[test]
+fn empty_else_and_final() {
+    let xml_else = "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\"><state id=\"s\"><onentry><if cond=\"true\"><else/></if></onentry></state></scxml>";
+    let obj_else: Value = serde_json::from_str(&xml_to_json(xml_else, true).unwrap()).unwrap();
+    assert!(obj_else["state"][0]["onentry"][0]["if_value"][0].get("else_value").is_some());
+
+    let xml_final = "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\"><state id=\"s\"><onentry><assign location=\"x\"><scxml><final/></scxml></assign></onentry></state></scxml>";
+    let obj_final: Value = serde_json::from_str(&xml_to_json(xml_final, true).unwrap()).unwrap();
+    assert_eq!(obj_final["state"][0]["onentry"][0]["assign"][0]["content"][0]["final"], serde_json::json!([{}]));
+
+    let rt_else = round_trip(xml_else);
+    assert_eq!(rt_else, obj_else);
+    let rt_final = round_trip(xml_final);
+    assert_eq!(rt_final, obj_final);
+}
+


### PR DESCRIPTION
## Summary
- implement basic recursive parsing in Rust converter library
- handle nested SCXML, script content, target splitting, and defaults
- add extensive Rust tests mirroring JS converter behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6882a7344c608333be9a041366d5866e