### PR TITLE
Support keep-empty in Rust CLI

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -67,7 +67,7 @@ fn convert_scxml_file(src: &Path, dest: Option<&Path>, verify: bool, keep_empty:
     match xml_to_json(&xml, !keep_empty) {
         Ok(json) => {
             if verify {
-                if json_to_xml(&json).is_ok() {
+                if json_to_xml(&json, true).is_ok() {
                     println!("Verified {}", src.display());
                 } else {
                     eprintln!("Failed to verify {}", src.display());
@@ -84,9 +84,16 @@ fn convert_scxml_file(src: &Path, dest: Option<&Path>, verify: bool, keep_empty:
     }
 }
 
-fn convert_scjson_file(src: &Path, dest: Option<&Path>, verify: bool, _keep_empty: bool) {
+/// Convert a scjson file to SCXML.
+///
+/// # Parameters
+/// - `src`: Source JSON file path.
+/// - `dest`: Optional output file path.
+/// - `verify`: When `true`, only validate the round trip.
+/// - `keep_empty`: Preserve empty fields when `true`.
+fn convert_scjson_file(src: &Path, dest: Option<&Path>, verify: bool, keep_empty: bool) {
     let json = fs::read_to_string(src).expect("read json");
-    match json_to_xml(&json) {
+    match json_to_xml(&json, !keep_empty) {
         Ok(xml) => {
             if verify {
                 if xml_to_json(&xml, true).is_ok() {
@@ -136,9 +143,9 @@ where
 fn validate_file(path: &Path) -> bool {
     let data = fs::read_to_string(path).expect("read file");
     let res = if path.extension().and_then(|s| s.to_str()) == Some("scxml") {
-        xml_to_json(&data, true).and_then(|j| json_to_xml(&j))
+        xml_to_json(&data, true).and_then(|j| json_to_xml(&j, true))
     } else if path.extension().and_then(|s| s.to_str()) == Some("scjson") {
-        json_to_xml(&data).and_then(|x| xml_to_json(&x, true))
+        json_to_xml(&data, true).and_then(|x| xml_to_json(&x, true))
     } else {
         return true;
     };

--- a/rust/tests/cli.rs
+++ b/rust/tests/cli.rs
@@ -21,6 +21,22 @@ fn create_scjson() -> String {
 }
 
 #[test]
+fn keep_empty_json_conversion() {
+    let dir = TempDir::new().unwrap();
+    let xml_path = dir.path().join("sample.scxml");
+    fs::write(&xml_path, create_scxml()).unwrap();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("scjson_rust").unwrap();
+    cmd.args(["json", xml_path.to_str().unwrap(), "--keep-empty"]);
+    cmd.assert().success();
+
+    let out_path = xml_path.with_extension("scjson");
+    let data: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out_path).unwrap()).unwrap();
+    assert!(data.get("datamodel_attribute").is_some());
+}
+
+#[test]
 fn shows_help() {
     let mut cmd = assert_cmd::Command::cargo_bin("scjson_rust").unwrap();
     cmd.arg("--help");
@@ -78,6 +94,21 @@ fn single_xml_conversion() {
     assert!(out_path.exists());
     let data = fs::read_to_string(out_path).unwrap();
     assert!(data.contains("scxml"));
+}
+
+#[test]
+fn keep_empty_xml_conversion() {
+    let dir = TempDir::new().unwrap();
+    let json_path = dir.path().join("sample.scjson");
+    fs::write(&json_path, create_scjson()).unwrap();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("scjson_rust").unwrap();
+    cmd.args(["xml", json_path.to_str().unwrap(), "--keep-empty"]);
+    cmd.assert().success();
+
+    let out_path = json_path.with_extension("scxml");
+    let data = fs::read_to_string(out_path).unwrap();
+    assert!(data.contains("datamodel=\"null\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow json_to_xml to drop empty fields with new parameter
- update convert_scjson_file to use keep_empty flag
- keep empty datamodel attributes when --keep-empty is passed
- add CLI tests for --keep-empty

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6882a74332208333abe54d4adc7a6e47