### PR TITLE
Improve JS converter parity

### DIFF
--- a/js/converters.js
+++ b/js/converters.js
@@ -499,6 +499,14 @@ function removeEmpty(value, key) {
     return undefined;
   }
   if (typeof value === 'string' && value.trim() === '') {
+    if (
+      key &&
+      (key.endsWith('_attribute') ||
+       key.endsWith('_value') ||
+       ['expr', 'cond', 'event', 'target', 'id', 'name', 'label'].includes(key))
+    ) {
+      return '';
+    }
     return undefined;
   }
   return value;
@@ -603,6 +611,8 @@ function jsonToXml(jsonStr) {
           nk = 'if';
         } else if (k === 'raise_value') {
           nk = 'raise';
+        } else if (k === 'else_value') {
+          nk = 'else';
         }
         for (const [attr, prop] of Object.entries(ATTRIBUTE_MAP)) {
           if (prop === nk) {


### PR DESCRIPTION
## Summary
- preserve empty attribute strings in removeEmpty
- map `else_value` back to `<else>` when writing XML
- ensure tests pass

## Testing
- `npm test --silent`
- `python py/uber_test.py -l javascript`

------
https://chatgpt.com/codex/tasks/task_e_6882cb4444448333899f6e202535ad93