### PR TITLE
Add JSDoc for CLI helpers

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,10 @@
  * Licensed under the BSD 1-Clause License.
  */
 
+/**
+ * @file Command line interface for converting SCXML and scjson files.
+ */
+
 const fs = require('fs');
 const path = require('path');
 const { Command } = require('commander');
@@ -63,26 +67,63 @@ program
     }
   });
 
+/**
+ * Convert all SCXML files in a directory to scjson.
+ *
+ * @param {string} inputDir - Directory containing SCXML files.
+ * @param {string} outputDir - Destination directory for scjson output.
+ * @param {boolean} recursive - Recurse into subdirectories when true.
+ * @param {boolean} verify - Verify conversion without writing output.
+ * @param {boolean} keepEmpty - Keep null or empty elements when true.
+ * @returns {boolean} True if all files converted successfully.
+ */
 function convertDirectoryJson(inputDir, outputDir, recursive, verify, keepEmpty) {
   const pattern = recursive ? '**/*.scxml' : '*.scxml';
   const files = require('glob').sync(pattern, { cwd: inputDir, nodir: true });
+  let success = true;
   files.forEach(f => {
     const src = path.join(inputDir, f);
     const dest = path.join(outputDir, f.replace(/\.scxml$/, '.scjson'));
-    convertScxmlFile(src, dest, verify, keepEmpty);
+    if (!convertScxmlFile(src, dest, verify, keepEmpty)) {
+      success = false;
+    }
   });
+  return success;
 }
 
+/**
+ * Convert all scjson files in a directory to SCXML.
+ *
+ * @param {string} inputDir - Directory containing scjson files.
+ * @param {string} outputDir - Destination directory for SCXML output.
+ * @param {boolean} recursive - Recurse into subdirectories when true.
+ * @param {boolean} verify - Verify conversion without writing output.
+ * @param {boolean} keepEmpty - Keep null or empty elements when true.
+ * @returns {boolean} True if all files converted successfully.
+ */
 function convertDirectoryXml(inputDir, outputDir, recursive, verify, keepEmpty) {
   const pattern = recursive ? '**/*.scjson' : '*.scjson';
   const files = require('glob').sync(pattern, { cwd: inputDir, nodir: true });
+  let success = true;
   files.forEach(f => {
     const src = path.join(inputDir, f);
     const dest = path.join(outputDir, f.replace(/\.scjson$/, '.scxml'));
-    convertScjsonFile(src, dest, verify, keepEmpty);
+    if (!convertScjsonFile(src, dest, verify, keepEmpty)) {
+      success = false;
+    }
   });
+  return success;
 }
 
+/**
+ * Convert a single SCXML file to scjson.
+ *
+ * @param {string} src - Path to the source SCXML file.
+ * @param {string} dest - Output path for the scjson file.
+ * @param {boolean} verify - Verify conversion without writing output.
+ * @param {boolean} keepEmpty - Keep null or empty elements when true.
+ * @returns {boolean} True if the conversion succeeded.
+ */
 function convertScxmlFile(src, dest, verify, keepEmpty) {
   const xmlStr = fs.readFileSync(src, 'utf8');
   try {
@@ -105,6 +146,14 @@ function convertScxmlFile(src, dest, verify, keepEmpty) {
   }
 }
 
+/**
+ * Convert a single scjson file to SCXML.
+ *
+ * @param {string} src - Path to the source scjson file.
+ * @param {string} dest - Output path for the SCXML file.
+ * @param {boolean} verify - Verify conversion without writing output.
+ * @returns {boolean} True if the conversion succeeded.
+ */
 function convertScjsonFile(src, dest, verify) {
   const jsonStr = fs.readFileSync(src, 'utf8');
   try {


### PR DESCRIPTION
## Summary
- expand module header for CLI
- document CLI helper functions in js/index.js
- return success booleans from directory helpers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883ea025f288333a7be38844691a5e1