### PR TITLE
Return validation info from converters

### DIFF
--- a/js/tests/converters.test.js
+++ b/js/tests/converters.test.js
@@ -13,7 +13,8 @@ const { xmlToJson } = require('../converters.js');
  */
 test('script text becomes object with content', () => {
   const xml = '<scxml xmlns="http://www.w3.org/2005/07/scxml"><script>foo</script></scxml>';
-  const jsonStr = xmlToJson(xml);
+  const { result: jsonStr, valid } = xmlToJson(xml);
+  expect(valid).toBe(true);
   const obj = JSON.parse(jsonStr);
   expect(obj.script).toBeDefined();
   expect(Array.isArray(obj.script)).toBe(true);
@@ -25,7 +26,8 @@ test('script text becomes object with content', () => {
  */
 test('transition target tokens split correctly', () => {
   const xml = '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s1"><transition target="a b"/></state></scxml>';
-  const jsonStr = xmlToJson(xml);
+  const { result: jsonStr, valid } = xmlToJson(xml);
+  expect(valid).toBe(true);
   const obj = JSON.parse(jsonStr);
   const trans = obj.state[0].transition[0];
   expect(Array.isArray(trans.target)).toBe(true);
@@ -38,7 +40,8 @@ test('transition target tokens split correctly', () => {
 test('invoke content scxml normalised', () => {
   const xml =
     '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><invoke><content><scxml><state id="i"/></scxml></content></invoke></state></scxml>';
-  const jsonStr = xmlToJson(xml);
+  const { result: jsonStr, valid } = xmlToJson(xml);
+  expect(valid).toBe(true);
   const obj = JSON.parse(jsonStr);
   const invoke = obj.state[0].invoke[0];
   expect(invoke.content).toBeDefined();
@@ -52,7 +55,8 @@ test('invoke content scxml normalised', () => {
 test('initial attributes map to correct keys', () => {
   const xml =
     '<scxml xmlns="http://www.w3.org/2005/07/scxml" initial="s0"><state id="s0" initial="s1"><state id="s1"/></state></scxml>';
-  const jsonStr = xmlToJson(xml);
+  const { result: jsonStr, valid } = xmlToJson(xml);
+  expect(valid).toBe(true);
   const obj = JSON.parse(jsonStr);
   expect(obj.initial).toEqual(['s0']);
   expect(obj.state[0].initial_attribute).toEqual(['s1']);
@@ -64,7 +68,9 @@ test('initial attributes map to correct keys', () => {
 test('assign and send defaults are applied', () => {
   const xml =
     '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><onentry><assign location="foo" expr="1"/><send event="e"/></onentry></state></scxml>';
-  const obj = JSON.parse(xmlToJson(xml));
+  const { result: jsonStr, valid } = xmlToJson(xml);
+  expect(valid).toBe(true);
+  const obj = JSON.parse(jsonStr);
   const entry = obj.state[0].onentry[0];
   expect(entry.assign[0].type_value).toBe('replacechildren');
   expect(entry.send[0].type_value).toBe('scxml');
@@ -77,7 +83,9 @@ test('assign and send defaults are applied', () => {
 test('empty else becomes object', () => {
   const xml =
     '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><onentry><if cond="true"><else/></if></onentry></state></scxml>';
-  const obj = JSON.parse(xmlToJson(xml));
+  const { result: jsonStr, valid } = xmlToJson(xml);
+  expect(valid).toBe(true);
+  const obj = JSON.parse(jsonStr);
   const entry = obj.state[0].onentry[0];
   expect(entry.if_value[0]).toHaveProperty('else_value');
   expect(entry.if_value[0].else_value).toEqual({});
@@ -89,7 +97,9 @@ test('empty else becomes object', () => {
 test('empty final element survives cleanup', () => {
   const xml =
     '<scxml xmlns="http://www.w3.org/2005/07/scxml"><state id="s"><onentry><assign location="x"><scxml><final/></scxml></assign></onentry></state></scxml>';
-  const obj = JSON.parse(xmlToJson(xml));
+  const { result: jsonStr, valid } = xmlToJson(xml);
+  expect(valid).toBe(true);
+  const obj = JSON.parse(jsonStr);
   const assign = obj.state[0].onentry[0].assign[0];
   expect(assign.content[0]).toHaveProperty('final');
   expect(assign.content[0].final).toEqual([{}]);
@@ -101,7 +111,9 @@ test('empty final element survives cleanup', () => {
 test('root transitions are dropped', () => {
   const xml =
     '<scxml xmlns="http://www.w3.org/2005/07/scxml"><transition target="s"/><state id="s"/></scxml>';
-  const obj = JSON.parse(xmlToJson(xml));
+  const { result: jsonStr2, valid: valid2 } = xmlToJson(xml);
+  expect(valid2).toBe(true);
+  const obj = JSON.parse(jsonStr2);
   expect(obj).not.toHaveProperty('transition');
   expect(obj.state[0].id).toBe('s');
 });

--- a/js/types/scjson-browser.d.ts
+++ b/js/types/scjson-browser.d.ts
@@ -13,7 +13,11 @@ declare module 'scjson/browser' {
    * @returns Validated SCJSON as pretty-printed JSON string.
    * @throws Error if validation fails.
    */
-  export function xmlToJson(xmlStr: string, omitEmpty?: boolean): string;
+  export function xmlToJson(xmlStr: string, omitEmpty?: boolean): {
+    result: string;
+    valid: boolean;
+    errors: object[] | null;
+  };
 
   /**
    * Converts SCJSON (as JSON string) to SCXML (as XML string).
@@ -21,5 +25,9 @@ declare module 'scjson/browser' {
    * @returns Valid SCXML string.
    * @throws Error if validation fails.
    */
-  export function jsonToXml(jsonStr: string): string;
+  export function jsonToXml(jsonStr: string): {
+    result: string;
+    valid: boolean;
+    errors: object[] | null;
+  };
 }


### PR DESCRIPTION
## Summary
- report schema validation results from `xmlToJson` and `jsonToXml`
- surface validation warnings in CLI conversions
- propagate directory convert results for proper exit codes
- update tests for new return structure

## Testing
- `npm test --silent`
- `poetry run pytest -q`
- `dotnet test Scjson.Tests/Scjson.Tests.csproj -v minimal`
- `mvn test` *(fails: PluginResolutionException)*
- `go test ./...`
- `cargo test`
- `swift test`
- `bundle install` *(fails: 403 Forbidden)*
- `busted tests`

------
https://chatgpt.com/codex/tasks/task_e_6883ea04e0508333a070ea5c1bacd54f