### PR TITLE
Fix Python namespace handling and update uber test

### DIFF
--- a/py/uber_test.py
+++ b/py/uber_test.py
@@ -305,7 +305,7 @@ def main(out_dir: str | Path = "uber_out", language: str | None = None) -> None:
         Limit the run to a single language key from :data:`LANG_CMDS`.
     """
 
-    handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+    handler = SCXMLDocumentHandler()
     scxml_files = sorted(TUTORIAL.rglob("*.scxml"))
     canonical = _canonical_json(scxml_files, handler)
     scxml_files = list(canonical.keys())
@@ -335,8 +335,6 @@ def main(out_dir: str | Path = "uber_out", language: str | None = None) -> None:
         xml_dir.mkdir(parents=True, exist_ok=True)
         try:
             json_args = ["json", str(TUTORIAL), "-o", str(json_dir), "-r"]
-            if lang == "python":
-                json_args.append("--skip-unknown")
             subprocess.run(
                 cmd + json_args,
                 check=True,


### PR DESCRIPTION
## Summary
- ensure SCXML parser adds the default namespace when missing
- stop skipping unknown elements in uber test

## Testing
- `pytest -q`
- `python py/uber_test.py -l javascript | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688520ed6a3483338afd5e0e6b897f58