### PR TITLE
Fix JS xml boolean attr handling

### DIFF
--- a/js/src/converters.js
+++ b/js/src/converters.js
@@ -760,6 +760,7 @@ function jsonToXml(jsonStr) {
     ignoreAttributes: false,
     format: true,
     suppressEmptyNode: true,
+    suppressBooleanAttributes: false,
   });
   let obj = JSON.parse(jsonStr);
   flattenContent(obj);


### PR DESCRIPTION
## Summary
- prevent XML builder from dropping boolean attribute values

## Testing
- `python uber_test.py -l javascript`

------
https://chatgpt.com/codex/tasks/task_e_68855b802a408333b3a78bfc00a52bc8