### PR TITLE
Fix whitespace handling in JS converter

### DIFF
--- a/py/uber_test.py
+++ b/py/uber_test.py
@@ -351,6 +351,15 @@ def main(out_dir: str | Path = "uber_out", language: str | None = None) -> None:
         if not _available(cmd, env):
             print(f"Skipping {lang}: executable not available")
             continue
+        if lang == "javascript":
+            subprocess.run(
+                ["npm", "run", "build"],
+                cwd=ROOT / "js",
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
         json_dir = out_root / lang / "json"
         xml_dir = out_root / lang / "xml"
         json_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- adjust whitespace collapsing to preserve leading newlines
- guard `fixOtherAttributes` against cycles
- add comments for new logic
- rebuild JS distribution
- ensure `npm run build` is executed before JS uber tests

## Testing
- `npm test --silent`
- `env PYTHONPATH=py python py/uber_test.py -l javascript`

------
https://chatgpt.com/codex/tasks/task_e_6886a43883c08333a282697f947e6af6