### PR TITLE
Fix JS removeEmpty attr retention

### DIFF
--- a/js/src/converters.js
+++ b/js/src/converters.js
@@ -1005,7 +1005,7 @@ function removeEmpty(value, key) {
       if (
         base.endsWith('_attribute') ||
         base.endsWith('_value') ||
-        ['expr', 'cond', 'event', 'target', 'id', 'name', 'label', 'text'].includes(key) ||
+        ['expr', 'cond', 'event', 'target', 'id', 'name', 'label', 'text'].includes(base) ||
         key === '@_xmlns'
       ) {
         return '';


### PR DESCRIPTION
## Summary
- ensure empty string attributes like `expr=""` remain after normalization

## Testing
- `npm run build`
- `python uber_test.py -l javascript`

------
https://chatgpt.com/codex/tasks/task_e_6886c4e5257c8333bbf8d26ad98705a0