### PR TITLE
Fix JS nested scxml defaults

### DIFF
--- a/js/src/converters.js
+++ b/js/src/converters.js
@@ -1161,6 +1161,15 @@ function jsonToXml(jsonStr) {
   obj = removeEmpty(obj) || {};
   const valid = validate(obj);
   const errors = valid ? null : validate.errors;
+  // Remove defaults injected by validation that would misidentify
+  // arbitrary XML content blocks as nested SCXML documents. Ajv
+  // populates ``version`` and ``datamodel_attribute`` for objects
+  // matching the ``Scxml`` schema. When the original JSON only
+  // contains a ``qname`` field these defaults lead to erroneous
+  // ``<scxml>`` wrappers being generated on output. Stripping the
+  // fields prior to conversion preserves parity with the Python
+  // implementation.
+  stripNestedDataAttrs(obj);
   function restoreKeys(value) {
     if (Array.isArray(value)) {
       return value.map(restoreKeys);


### PR DESCRIPTION
## Summary
- prevent Ajv defaults from converting arbitrary XML fragments to `<scxml>`
- rebuild JS package

## Testing
- `npm run build`
- `python py/uber_test.py -l javascript`
- `python py/uber_test.py -l python`


------
https://chatgpt.com/codex/tasks/task_e_6886cdb660c88333ae3730b2188fccb6