### PR TITLE
Fix JS intial attribute recursion

### DIFF
--- a/js/src/converters.js
+++ b/js/src/converters.js
@@ -585,8 +585,8 @@ function fixOtherAttributes(value) {
       value.other_attributes.intial = value.intial;
       delete value.intial;
     }
-    for (const v of Object.values(value)) {
-      if (v === value) continue;
+    for (const [k, v] of Object.entries(value)) {
+      if (v === value || k === 'other_attributes') continue;
       fixOtherAttributes(v);
     }
     delete value[VISITED_FLAG];


### PR DESCRIPTION
## Summary
- avoid infinite recursion in `fixOtherAttributes`
- reduce uber test error count for JavaScript

## Testing
- `python -m pytest -q`
- `python uber_test.py -l javascript`

------
https://chatgpt.com/codex/tasks/task_e_6886d8c5b2dc8333b8106c62d4f2ac7a