### PR TITLE
V0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ single version stream.
 
 | Language | Path                  | Latest version  | Per-package log |
 |----------|-----------------------|-----------------|------------------|
-| Python   | `py/`                 | 0.4.1           | [`py/CHANGELOG.md`](py/CHANGELOG.md) |
+| Python   | `py/`                 | 0.4.2           | [`py/CHANGELOG.md`](py/CHANGELOG.md) |
 | Ruby     | `ruby/`               | 0.4.1           | (in `git log`)   |
 | JS       | `js/`                 | 0.4.1           | (in `git log`)   |
 | Rust     | `rust/`               | 0.4.1           | (in `git log`)   |
@@ -17,6 +17,16 @@ single version stream.
 | C#       | `csharp/`             | (csproj)        | (in `git log`)   |
 
 ## Cross-language entries
+
+### 2026-06-20 — Python 0.4.2 (constrained-ECMAScript execution + M1 IR; Python-only)
+
+Python-only release (no JS/Ruby/Rust/Java changes). Adds the constrained-ECMAScript
+datamodel engine (`scjson.ecmascript_normalizer`), the M1 Executable IR
+(`scjson.exec_ir` + `lower_document`), admitted-`<script>` statement lowering, and a
+bounded vector-generation coverage search (fixes the `<parallel>`+`<invoke>` hang).
+Drives the Infinity Stack iState SCXML→Rust generator (parent
+`docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md`). See [`py/CHANGELOG.md`](py/CHANGELOG.md)
+0.4.2 and `docs/concepts/ERRATA.md` ERRATA-002 (vector bound) + ERRATA-003 (`In()` gap).
 
 ### 2026-05-28 — 0.4.1 release (TypeScript helpText surface)
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -65,9 +65,9 @@ The table below summarizes the current Python engine feature coverage relative t
 |------|---------------|--------------|-----------------------|
 | Execution algorithm | Macro/microstep with quiescence | Same | Equivalent semantics |
 | Transition selection | Document order; multi-token, `*`, `error.*` | Same | Equivalent |
-| Condition evaluation | Sandboxed Python datamodel (`safe_eval`) | JS datamodel | Equivalent for tests; non-boolean cond → `error.execution` in Python |
-| Executable content | assign, log, raise, if/elseif/else, foreach, send, cancel | Same | Equivalent; `script` is a warning/no-op in Python ([SCION](https://www.npmjs.com/package/scion) executes JS) |
-| `script` blocks | No-op (warn) | Executes JS | Expected difference; tests avoid requiring `script` side effects |
+| Condition evaluation | Sandboxed Python datamodel (`safe_eval`) or ECMAScript normalizer (M1P6 G2) | JS datamodel | ECMAScript expressions normalized to Python before `safe_eval`; inadmissible forms → `error.execution` |
+| Executable content | assign, log, raise, if/elseif/else, foreach, send, cancel, script | Same | Equivalent; `script` executes the admitted ECMAScript subset (M1P6 D-M1P6-2) when `datamodel="ecmascript"` |
+| `script` blocks | Executes admitted ECMAScript subset (assign + if) | Executes JS | Equivalent for admitted forms (D-M1P6-2); inadmissible forms emit `error.execution` per D-M1P6-8 |
 | History | Shallow + deep | Same | Equivalent; deep restores exact descendant leaves |
 | Parallel completion | Region done → parent done | Same | Equivalent ordering |
 | Done events | `done.state.*`, `done.invoke*` | Same | Equivalent; see invoke ordering notes |
@@ -80,6 +80,46 @@ The table below summarizes the current Python engine feature coverage relative t
 | Finalize semantics | Runs in invoking state; `_event` = `{name,data,invokeid}` | Same | Equivalent |
 | Invoke ordering | Modes: `tolerant` (default), `strict`, `scion` | N/A | `scion` mode aligns `done.invoke` ordering with [SCION](https://www.npmjs.com/package/scion) (generic before id-specific, push-front) |
 | Step-0 normalization | Compare tooling strips step-0 noise | N/A | Reduces diffs due to initial transitions visibility |
+
+---
+
+## ECMAScript Datamodel Admission (M1P6 G2)
+
+The Python engine now admits `datamodel="ecmascript"` alongside the default `python` datamodel.
+ECMAScript expressions and `<script>` bodies are normalized to Python by the
+`ecmascript_normalizer` module before evaluation.
+
+**Admitted ECMAScript subset (D-M1P6-2):**
+
+| JS form | Python equivalent |
+|---------|------------------|
+| `&&` | `and` |
+| `\|\|` | `or` |
+| `!` | `not ` |
+| `===` | `==` |
+| `!==` | `!=` |
+| `true` / `false` | `True` / `False` |
+| `null` / `undefined` | `None` |
+| `parseInt(x)` / `parseInt(x, r)` | `int(x)` / `int(x, r)` |
+| `String(x)` | `str(x)` |
+| `Number(x)` | `float(x)` |
+| `'str' + intVar` | `'str' + str(intVar)` (JS coercion) |
+| `{key: val}` (object literal) | `{"key": val}` (Python dict) |
+| `// comment` / `/* ... */` | stripped before evaluation |
+| `if (cond) { ... }` (script only) | `if cond:\n    ...` |
+
+**_event binding:** When `datamodel="ecmascript"`, the `_event` object exposes
+`.name` and `.data` in condition and expression contexts.
+
+**Inadmissible forms** (`=>`, `new`, `typeof`, `for`, `while`, `class`, template
+literals, etc.) raise `ECMAScriptNormalizationError` with diagnostic
+`"unsupported-ecmascript"` and cause the engine to emit `error.execution` per
+D-M1P6-8.
+
+**Verified against:** the Alex Z tutorial Dining Philosophers machine
+(`tutorial/Examples/StateCharts/DiningPhilosphersProblem/machine_dining_philosphers.scxml`)
+with five parallel philosopher child machines loading correctly and entering
+their initial `Thinking` state.
 
 ---
 

--- a/docs/concepts/ERRATA.md
+++ b/docs/concepts/ERRATA.md
@@ -37,6 +37,7 @@ exhaustion; `blocked` is owned by M1P6 D-M1P6-8, not by the search.)
 |------------|--------|-------------------------------------------------|------------|--------------|
 | ERRATA-001 | 🟢     | scjson@0.4.0 TypeScript surface missing helpText | 2026-05-28 | CONV-E       |
 | ERRATA-002 | 🟢     | Vector-generation BFS has no candidate/time budget — permanent hang on `<parallel>`+`<invoke>` machines | 2026-06-19 | EXEC-E (`SCJSON-EXEC-00-CONCEPTS.md`) |
+| ERRATA-003 | 🟡     | `In()` cross-region predicate not in the admitted ECMAScript subset — blocks real infotainment control cores | 2026-06-20 | M1P6 (`docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md` D-M1P6-2) |
 
 ---
 
@@ -290,6 +291,37 @@ a TODO per spec (optional for first landing).
 - Reciprocal istate entry: `softoboros/docs/todo/istate/ERRATA.md` ERRATA-006.
 - Downstream demo: `ops/packer/submodules/rlvgl/docs/concepts/SCTD-00-CONCEPTS.md`
   §8 (iState MCP generation boundary).
+
+---
+
+## ERRATA-003 — `In()` cross-region predicate not in the admitted ECMAScript subset
+
+- **Status**: 🟡 diagnosed 2026-06-20 (workaround prescribed; admitted-subset extension is a future generator phase). Surfaced during the SCTD Media Player feasibility assessment of the Skoda Bolero infotainment machine.
+- **First seen**: 2026-06-20, lowering `tutorial/Examples/Qt/SkodaBoleroInfotainment/Model/bolero.scxml` through `exec_ir.lower_document`.
+- **Owning phase**: M1P6 (`docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md` §"Admitted ECMAScript Subset", D-M1P6-2).
+
+### Symptom
+
+`bolero.scxml` (a Qt compound document — the `_virtual*.scxml` siblings are editor artifacts already merged inline; the machine has **0** `<invoke>` and 203 states) lowers 87% admitted, but its **media-transport control core is a structural dead end**: `mediaPlayerSourceCheck` decides play-vs-pause via `cond="In('muteOn')"` / `cond="In('muteOff')"`, and `mediaStopped`/`mediaPlaying` onentry choose repeat-vs-next via `In("mediaRepeatTrack")`. `In(...)` is an SCXML **runtime cross-region active-state predicate**, not an ECMAScript expression, so the constrained front-end (D-M1P6-2) lowers each `In()` to `UnsupportedExpr` → falsey at runtime. Net: neither play nor pause ever fires; the control loop cannot run. 10 of the machine's 25 `reject` diagnostics are `In()` calls (plus 9 `parse-error` from radio helper functions stored as `<data expr="function(x){...}">`, which JS-`function` syntax also outside the subset).
+
+### Root cause
+
+D-M1P6-2 admits expressions/statements but not the SCXML `In(<stateid>)` predicate (it needs the runtime to answer "is state X in the active configuration" — which the IR/runtime *does* track, but the front-end has no admitted form for it). Real infotainment/automotive charts (Bolero, likely Morse and others) lean on `In()` for orthogonal-region-aware dispatch, so this gap blocks faithful lowering of that class of machine.
+
+### Fix prescription
+
+- **Now (workaround, used for SCTD):** normalize the machine — replace `In(<region-state>)` checks with explicit datamodel state variables that mirror the orthogonal-region intent (e.g. `s_mute`/`s_repeat`/`s_source`), an admitted D-M1P6-2 form. This is the SCTD-00 §5.3 normalized-form path with provenance back to the upstream source; it is how the SCTD "Media Player" machine is produced (a normalized media-player derived from Bolero, lowering with 0 diagnostics).
+- **Future (real fix):** extend the admitted subset to support `In(<stateid>)` as a `cond`-context predicate, lowered to a runtime configuration-membership check (the runtime already tracks the active set). This is the path to lowering the **real** Bolero control core. It is an admitted-subset change → a M1P6 D-M1P6-2 amendment (Specification Required) + a new scjson generator phase; out of scope for v0.4.2.
+
+### Verification
+
+Pending the future extension. The workaround is verified: the normalized media-player derived from Bolero lowers with 0 diagnostics, emits, and `cargo check` passes (SCTD demo, 2026-06-20).
+
+### Tracking
+
+- Admitted-subset owner: `docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md` D-M1P6-2 (a reciprocal note records the `In()` gap + the normalized-media-player conformance decision).
+- SCTD consumer: rlvgl `docs/concepts/SCTD-00-CONCEPTS.md` §5.1/§5.3 (Media Player = normalized, provenance to bolero).
+- Also surfaced: radio helper functions stored as `<data expr="function(){…}">` (JS function-literals) are likewise outside D-M1P6-2; same normalize-or-extend disposition.
 
 ---
 

--- a/docs/concepts/ERRATA.md
+++ b/docs/concepts/ERRATA.md
@@ -26,13 +26,17 @@ stay as historical record. Status icons:
 
 ## Open Questions
 
-(none — ERRATA-001 fix path is fully prescribed below)
+(none — EOQ-001-ERRATA-002 resolved 2026-06-20: EXEC-E §EXEC-E-D1..D5 ratified the
+bound — `max_candidates=2000` + `time_budget_ms=30000` defaults, construct-aware
+depth reduction, terminal `limited` (partial vectors + `truncated:true`) on budget
+exhaustion; `blocked` is owned by M1P6 D-M1P6-8, not by the search.)
 
 ## Index
 
 | ID         | Status | Title                                           | First seen | Owning phase |
 |------------|--------|-------------------------------------------------|------------|--------------|
 | ERRATA-001 | 🟢     | scjson@0.4.0 TypeScript surface missing helpText | 2026-05-28 | CONV-E       |
+| ERRATA-002 | 🟢     | Vector-generation BFS has no candidate/time budget — permanent hang on `<parallel>`+`<invoke>` machines | 2026-06-19 | EXEC-E (`SCJSON-EXEC-00-CONCEPTS.md`) |
 
 ---
 
@@ -168,6 +172,124 @@ $ grep -n "0\.4\.0" js/package.json py/pyproject.toml rust/Cargo.toml \
 - Downstream: `softoboros/docs/todo/istate/TODO-ISTATE-08-HELP-TEXT-ADOPTION.md`
   §16 "ISTATE08b backend half landed; frontend half deferred to scjson
   v0.4.1" (2026-05-27 entry).
+
+---
+
+## ERRATA-002 — Vector-generation BFS has no candidate/time budget — permanent hang on `<parallel>`+`<invoke>` machines
+
+- **Status**: 🟢 resolved 2026-06-20 (EXEC-E §EXEC-E-D1..D5 ratified the bound;
+  fix landed in the EXEC-E vector-search-bound commit on this branch). EOQ-001-ERRATA-002
+  resolved.
+- **First seen**: 2026-06-19, during the iState-over-MCP codegen probe for the
+  rlvgl SCTD-01 tutorial-demo effort (a faithful Dining Philosophers machine
+  submitted to `istate_codegen_create target_langs=["rust"]`).
+- **Owning phase**: EXEC-E — Vector Generation Phase 3
+  (`docs/concepts/SCJSON-EXEC-00-CONCEPTS.md` §EXEC-E, currently open; acceptance
+  item "EXEC-E vector-generation Phase 3 plan drafted before implementation" is
+  unchecked).
+
+### Symptom
+
+A codegen job over the Alex Z tutorial Dining Philosophers machine
+(`tutorial/Examples/StateCharts/DiningPhilosphersProblem/machine_dining_philosphers.flat.scxml`
+— `datamodel="ecmascript"`, root `<parallel>` with ten children, five nested
+`<invoke>` blocks each carrying an inline `<content><scxml>…</scxml></content>`
+child machine, `<foreach>`, dynamic `<send eventexpr= targetexpr= delayexpr=>`)
+sits in `STARTED` indefinitely — observed 30+ minutes with no `error`, no
+`warnings`, no `artifacts`, no terminal transition. A trivial 4-state
+`datamodel="null"` machine through the identical path SUCCEEDED in ≤14 s,
+isolating the hang to machine complexity, not a generator outage.
+
+The hang is in vector generation, before any Rust template is rendered. Pinned
+against scjson `HEAD = 25c79d7` (2026-06-19):
+
+- `py/vector_lib/search.py:82` — the `while frontier:` BFS loop. It is
+  depth-capped (`py/vector_lib/search.py:84`, `if len(seq) >= max_depth`) but
+  has **no candidate-count cap and no wall-clock budget**; every candidate that
+  increases coverage is appended to the frontier (`search.py:100-101`), so
+  breadth grows ~`|alphabet|^depth`.
+- `py/vector_gen.py` — each evaluated candidate calls a `ctx_factory()` that
+  re-instantiates a fresh `DocumentContext.from_json_file(...)`. For this chart
+  that means re-entering all parallel regions and starting five
+  `SCXMLChildHandler` instances from inline `<content>` SCXML on **every** node
+  visited.
+
+The combination — large event alphabet × `max_depth=4` (the value the iState
+caller passes, `backend/istate/codegen/vectors.py:60`) × an O(parallel × inline-
+invoke child-machine init) per-node cost — makes the search effectively
+non-terminating in practical wall-clock. (Runner-up, not yet excluded: a single
+`ctx_factory()` blocking inside the child-invoke `_pump()` for a machine whose
+inline children never quiesce.)
+
+### Root cause
+
+`generate_sequences` bounds only search *depth*, never *breadth* or *time*, and
+the per-candidate context construction is unexpectedly expensive for machines
+that combine a root `<parallel>` with inline-`<content>` `<invoke>` children.
+EXEC-E (parallel/invoke corpus expansion + vector minimization) was never
+drafted, so no committed bound exists; the defaults in
+`generate_sequences(... max_depth=2, limit=1)` are the only guard, and the
+iState caller overrides `max_depth` to 4. There is no terminal "search exhausted
+the budget" outcome, so the only signal a too-complex machine produces is an
+indefinite `STARTED`.
+
+### Downstream impact
+
+- iState codegen (`istate.codegen.generate`) inherits the hang and never
+  reaches a terminal job state — see the reciprocal istate-side entry
+  `softoboros/docs/todo/istate/ERRATA.md` ERRATA-006 (missing codegen watchdog +
+  shallow context builder).
+- rlvgl SCTD-01 (faithful tutorial-machine demo) is blocked on this:
+  `ops/packer/submodules/rlvgl/docs/concepts/SCTD-00-CONCEPTS.md` §8 names iState
+  MCP as the generation authority, and the tutorial machines cannot be generated
+  until the search is bounded.
+
+### Fix prescription
+
+EXEC-E (spec first, per scjson `CLAUDE.md` — this changes cross-language trace
+generation behavior):
+
+1. Add a committed bound to `generate_sequences` in `py/vector_lib/search.py`:
+   a candidate-count cap (e.g. `max_candidates`) and a wall-clock budget
+   (`time_budget_ms`), checked at the top of the `while frontier:` loop, plus
+   a construct-aware depth/alphabet reduction when the chart contains
+   `<parallel>` and/or `<invoke>` (detectable from the doc before the search).
+2. Define the terminal outcome of an exhausted/over-budget run: emit a
+   `limited` result carrying whatever partial vectors were found plus a
+   `truncated: true` marker, **or** a `blocked` result with an explicit reason
+   — the choice is EOQ-001-ERRATA-002, to be ratified under EXEC-E.
+3. Ensure `ctx_factory()` reuse / memoization where safe, so repeated node
+   evaluation does not re-pay full inline-`<invoke>` child-machine
+   initialization for an unchanged prefix.
+4. Cross-check: the trivial null-datamodel baseline must stay byte-identical
+   (no churn in existing golden vectors); add a regression vector from a small
+   `<parallel>`+`<invoke>` machine that completes under the new budget.
+
+The reciprocal istate-side watchdog (ERRATA-006) is belt-and-braces: even with
+this fix, the codegen Celery task MUST carry an effective per-task time limit so
+no future construct can park a job in `STARTED` forever.
+
+### Verification
+
+✅ 2026-06-20. `generate_sequences`/`generate_vectors` now carry `max_candidates`
++ `time_budget_ms` budgets checked at the top of the BFS loop, plus EXEC-E-D2
+construct-aware depth reduction and a `truncated` marker. Evidence:
+(a) the Dining Philosophers machine now **terminates in ~39 s** with 22 partial
+sequences and `truncated: true` (was an indefinite 30+ min hang);
+(b) the existing null-datamodel golden vectors are byte-identical — full scjson
+suite **480 passed / 1 skipped** (baseline 410/1 before the EXEC-E + ecmascript
+work, all prior tests still green);
+(c) a new bounded `<parallel>`+`<invoke>` regression machine (`test_vector_search.py`)
+completes under budget at effective depth 2. Memoization (EXEC-E-D3) deferred with
+a TODO per spec (optional for first landing).
+
+### Tracking
+
+- Owning phase: `docs/concepts/SCJSON-EXEC-00-CONCEPTS.md` §EXEC-E (to be
+  drafted with the bound decision + EOQ-001-ERRATA-002 resolution).
+- Reciprocal istate entry: `softoboros/docs/todo/istate/ERRATA.md` ERRATA-006.
+- Downstream demo: `ops/packer/submodules/rlvgl/docs/concepts/SCTD-00-CONCEPTS.md`
+  §8 (iState MCP generation boundary).
 
 ---
 

--- a/docs/concepts/SCJSON-EXEC-00-CONCEPTS.md
+++ b/docs/concepts/SCJSON-EXEC-00-CONCEPTS.md
@@ -147,17 +147,162 @@ Independent from: Python 0.3.7 release unless release scope expands.
 
 ### EXEC-E: Vector Generation Phase 3
 
-Goal: move vector minimization and parallel/invoke corpus expansion out of
-generic TODOs into a phase with explicit trace dependencies.
+**Status: owner-ratified 2026-06-20. This section is normative. The acceptance
+checklist item "EXEC-E vector-generation Phase 3 plan drafted before
+implementation" is satisfied by this section.**
 
-Output:
+The following decisions close EOQ-001-ERRATA-002 (see
+`docs/concepts/ERRATA.md` ERRATA-002 for the symptom evidence and root cause).
+Implementers MUST satisfy all five sub-decisions; changing any frozen value
+requires a §15 amendment to this document before implementation.
 
-- Work plan for delta-preserving minimization.
-- Corpus expansion criteria for parallel, history, invoke, and step-0 variance.
+#### EXEC-E-D1: Candidate-count cap and wall-clock budget (Standards Action)
 
-Dependencies: EXEC-D for invoke ordering-sensitive vectors.
+`generate_sequences` in `py/vector_lib/search.py` currently bounds only
+sequence length (`if len(seq) >= max_depth` at `search.py:84`). It has no
+bound on how many candidates accumulate in `frontier` or on elapsed wall-clock
+time.  ERRATA-002 shows that a root `<parallel>` with five inline-`<content>`
+`<invoke>` children and `max_depth=4` (the value the iState caller passes at
+`backend/istate/codegen/vectors.py:63`) makes the search effectively
+non-terminating because alphabet breadth grows as `|alphabet|^depth` and each
+frontier node calls `ctx_factory()` in full.
 
-Independent from: converter schema audit except for input normalization.
+`generate_sequences` MUST accept two additional keyword parameters:
+
+- `max_candidates: int` — maximum cumulative frontier entries to evaluate
+  before stopping the `while frontier:` loop. Checked at the top of the loop,
+  before popping the next sequence, so the loop exits cleanly with whatever
+  partial results have been collected.
+- `time_budget_ms: int` — elapsed wall-clock budget in milliseconds, measured
+  from the moment `generate_sequences` is entered. Checked at the top of the
+  same loop, immediately after the `max_candidates` check.
+
+**Default values (proposed; flag for owner confirmation before freezing):**
+`max_candidates=2000`, `time_budget_ms=30000` (30 s). These are deliberately
+conservative for the common null-datamodel case, which completes in
+milliseconds and is unaffected. The iState caller MAY lower these further for
+interactive use.
+
+Registration policy: **Standards Action** — changing either default requires
+a §15 amendment to this document.
+
+#### EXEC-E-D2: Construct-aware reduction (Standards Action)
+
+When the chart being searched contains at least one `<parallel>` element or at
+least one `<invoke>` element (detectable from the SCJSON document before the
+first `ctx_factory()` call), the search MUST apply a construct-aware
+reduction: the effective `max_depth` passed into the BFS expansion is capped
+at `min(max_depth, 2)` for those charts, and the alphabet is reduced to the
+set of events that appear in `event` attributes of `<transition>` elements in
+the top-level (non-child-machine) document. The reduction is applied
+statically, before the loop, and logged as a diagnostic so callers can observe
+it.
+
+**Rationale:** The per-candidate `ctx_factory()` call for a chart that
+combines `<parallel>` and inline-`<content>` `<invoke>` re-instantiates all
+parallel regions and starts each `SCXMLChildHandler` from scratch on every
+frontier node (identified in ERRATA-002 as the dominant cost factor). The
+depth+alphabet reduction substantially contracts the frontier while retaining
+coverage of the top-level event/state topology. Full child-machine vector
+generation is out of scope for EXEC-E; it depends on M1P6 G2 (the IR
+front-end) and is deferred.
+
+**A future amendment MAY relax the depth cap for `<parallel>`-only charts
+(no `<invoke>`) once ctx-factory memoization is implemented (see EXEC-E-D3).**
+
+Registration policy: **Standards Action** — the reduction trigger conditions
+and the cap formula require a §15 amendment to change.
+
+#### EXEC-E-D3: ctx_factory memoization for repeated prefixes (Specification Required)
+
+For each distinct sequence prefix evaluated during BFS, the `ctx_factory()`
+result SHOULD be reused across frontier nodes that share that prefix, rather
+than re-instantiating from scratch. Implementation MAY memoize by prefix tuple
+key, constructing a fresh context only for novel prefixes. This is particularly
+load-bearing for inline-`<invoke>` charts because each `SCXMLChildHandler`
+initialization re-parses the inline `<content>` XML.
+
+Memoization is optional for the first landing of EXEC-E-D1 + EXEC-E-D2 (the
+budget+reduction alone resolves the hang). It MUST land before the
+construct-aware depth cap is relaxed per the note in EXEC-E-D2.
+
+Registration policy: **Specification Required** — implementation details may
+evolve without a §15 amendment as long as observable behavior (sequence
+output, coverage scores, and the `limited`/`blocked` terminal outcomes) is
+unchanged.
+
+#### EXEC-E-D4: Terminal outcomes — `limited` and `blocked` (Standards Action)
+
+This sub-decision resolves EOQ-001-ERRATA-002 and is co-owned with M1P6
+D-M1P6-8 (`docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md` §"Frozen Decisions"
+D-M1P6-8, ratified 2026-06-20). Do NOT restate the M1P6 definition here;
+implementers MUST read D-M1P6-8 as the primary normative source.
+
+The commitment here is the vector-search-layer contract:
+
+- **`limited`**: if `generate_sequences` exits the `while frontier:` loop
+  because `max_candidates` was reached or `time_budget_ms` elapsed, it MUST
+  return whatever partial vector list has been collected (possibly empty),
+  and MUST set a `truncated: True` flag on the return value (as a named
+  result object or an out-of-band signal agreed with the caller). The caller
+  (e.g. `vector_gen.generate_vectors` and the iState codegen path in
+  `backend/istate/codegen/vectors.py`) MUST propagate `truncated: True`
+  through to the terminal job status so consumers receive a `limited` outcome
+  rather than a silent success or an indefinite `STARTED`.
+- **`blocked`**: an un-lowerable construct (as defined by M1P6 D-M1P6-8) is
+  NOT signaled by `generate_sequences` — it is a compile-time diagnostic
+  emitted by the IR lowering layer (M1P6 G2). `blocked` is not a vector-search
+  outcome and MUST NOT be synthesized inside `generate_sequences`.
+- **Indefinite `STARTED`**: prohibited. A run that cannot terminate within the
+  committed budget MUST produce `limited`, never hang.
+
+Registration policy: **Standards Action** — the names `limited`/`blocked`, the
+`truncated` flag semantics, and the prohibition on indefinite `STARTED` are
+cross-family invariants (consumed by istate ERRATA-006 and rlvgl SCTD-00 §8).
+Changing them requires a §15 amendment here and a reciprocal amendment to M1P6
+D-M1P6-8.
+
+#### EXEC-E-D5: Regression corpus requirement (Specification Required)
+
+The following regression contract MUST hold across all EXEC-E implementation
+PRs:
+
+1. **Null-datamodel baseline unchanged.** The golden vectors for the existing
+   null-datamodel test machines in the scjson corpus MUST remain byte-identical
+   after EXEC-E-D1..D4 land. No churn in existing output is acceptable. The
+   existing `PYTHONPATH=py pytest -q py/tests` suite is the verification gate.
+
+2. **Bounded parallel+invoke regression vector.** A new corpus machine
+   containing at least one `<parallel>` element and at least one
+   inline-`<content>` `<invoke>` element MUST be added to the test corpus.
+   The vector-generation run for that machine MUST complete within the
+   committed `time_budget_ms` and MUST produce either a non-empty `limited`
+   result or a `success` result with at least one vector. The machine SHOULD
+   be small enough that the BFS completes well under the budget on any CI
+   runner (suggested: two parallel regions, one nested `<invoke>` with a
+   two-state child machine, alphabet of three events).
+
+Registration policy: **Specification Required** — the corpus machine shape may
+evolve; the two-part invariant (null-datamodel no-churn + bounded
+parallel+invoke completion) requires only a PR-level note to change.
+
+#### EXEC-E: Output summary
+
+- `py/vector_lib/search.py` extended with `max_candidates` + `time_budget_ms`
+  parameters, construct-aware depth/alphabet reduction, and `truncated` signal.
+- `py/vector_gen.py` updated to propagate `truncated` to callers.
+- iState codegen path (`backend/istate/codegen/vectors.py`) updated to treat
+  `truncated: True` as a `limited` terminal outcome.
+- New bounded `<parallel>`+`<invoke>` regression machine added to the corpus.
+
+Dependencies: EXEC-E-D4 and the `limited`/`blocked` naming are jointly owned
+with M1P6 D-M1P6-8; EXEC-E-D3 memoization SHOULD land before any future
+relaxation of the EXEC-E-D2 depth cap; invoke ordering semantics remain under
+EXEC-D.
+
+Independent from: converter schema audit, Ruby conformance (EXEC-F), and the
+M1P6 IR front-end (EXEC-E resolves the hang at the search layer; full
+child-machine vectors depend on M1P6 G2).
 
 ### EXEC-F: Ruby Execution Conformance
 
@@ -191,7 +336,9 @@ EXEC-D, EXEC-E, and EXEC-F are deferred to larger initiatives.
   entries now carry inline reasons.
 - [ ] EXEC-D invoke/finalize ordering concepts drafted before behavioral
   changes.
-- [ ] EXEC-E vector-generation Phase 3 plan drafted before implementation.
+- [x] EXEC-E vector-generation Phase 3 plan drafted before implementation.
+  Ratified 2026-06-20; see §5 EXEC-E for the committed bound (EXEC-E-D1..D5)
+  resolving EOQ-001-ERRATA-002.
 - [ ] EXEC-F Ruby conformance TODOs rebaselined against this doc.
 
 ## Section 8. Manager Notes
@@ -224,11 +371,27 @@ initiative.
 - `docs/TODO-ENGINE-PY.md`
 - `docs/TODO-ENGINE-RUBY.md`
 - `docs/concepts/SCJSON-00-CONCEPTS.md`
+- `docs/concepts/ERRATA.md` (ERRATA-002: vector-generation BFS hang; symptom
+  evidence and root cause for EXEC-E)
 - `py/scjson/cli.py`
 - `py/scjson/context.py`
 - `py/uber_test.py`
+- `py/vector_lib/search.py` (EXEC-E: `generate_sequences` BFS, `while
+  frontier:` at line 82, depth cap at line 84, frontier append at lines
+  100–101)
+- `py/vector_gen.py`
 - `ruby/lib/scjson/engine/context.rb`
+- `softoboros/backend/istate/codegen/vectors.py` (iState caller; passes
+  `max_depth=4, limit=1` at line 63)
+- `softoboros/docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md` (M1P6 D-M1P6-8:
+  terminal codegen outcomes; G1 gate: vector-search bound)
 
 ## Section 11. Change Log
 
 - 2026-05-14: Initial execution concepts document.
+- 2026-06-20: §5 EXEC-E expanded with five normative sub-decisions
+  (EXEC-E-D1..D5) committing the candidate-count cap, wall-clock budget,
+  construct-aware reduction, ctx_factory memoization policy, `limited`/`blocked`
+  terminal outcomes, and regression corpus requirement. Resolves
+  EOQ-001-ERRATA-002 (`docs/concepts/ERRATA.md` ERRATA-002). Acceptance
+  checklist item EXEC-E marked satisfied. §10 updated with EXEC-E cited files.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.softobros</groupId>
     <artifactId>scjson</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scjson",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scjson",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "BSD-1-Clause",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scjson",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A JSON-based serialization of SCXML (State Chart XML) with SCXML/SCML execution tooling and converters.",
   "author": "Softoboros Technology Inc. <ira@softoboros.com>",
   "repository": {

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -6,6 +6,45 @@ The Python package version is independent of the JS, Ruby, Rust, Java, Swift,
 Lua, Go, and C# package versions; cross-language work is coordinated through
 the top-level [`CHANGELOG.md`](../CHANGELOG.md).
 
+## 0.4.2 — 2026-06-20
+
+Python-only release; no cross-language (JS/Ruby/Rust/Java) changes. Adds the
+constrained-ECMAScript execution + codegen surface used by the Infinity Stack
+iState Rust generator (parent `docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md`).
+
+### Added
+
+- **Constrained ECMAScript datamodel (`datamodel="ecmascript"`).** New
+  `scjson.ecmascript_normalizer` lowers the admitted JS subset (per M1P6
+  D-M1P6-2: `&&`/`||`/`!`, `===`/`!==`, `parseInt`/`String`/`Number`,
+  `<str>.replace`, object/array literals, computed member access, dynamic
+  map keys, `if`/assignment statement bodies) to Python-evaluable forms; the
+  engine gate in `context.py` now admits `ecmascript` through this path.
+  Unadmitted forms emit an `unsupported-ecmascript` diagnostic — never a
+  silent mis-eval. `null`/`python` datamodels are byte-for-byte unchanged.
+- **M1 Executable IR (`scjson.exec_ir`).** Concrete IR + `lower_document`:
+  the M1P6 value model, 7 ExpressionNode + 7 ActionNode families, `<foreach>`,
+  inline-`<content>` `<invoke>` → nested machine IR (depth-bounded), dynamic
+  `<send>` slots, recursive state tree. Admitted multi-statement `<script>`
+  bodies lower to `AssignNode`/`IfNode` sequences (else blocked whole as a
+  capability call). Additive layer; does not change engine execution.
+
+### Changed
+
+- **Vector-generation coverage search is bounded** (`vector_lib/search.py`,
+  `vector_gen.py`): `max_candidates` + `time_budget_ms` budgets +
+  construct-aware depth reduction for `<parallel>`/`<invoke>`; budget
+  exhaustion yields a terminal `limited` result (`truncated: true`) instead
+  of an unbounded hang. See `docs/concepts/SCJSON-EXEC-00-CONCEPTS.md`
+  §EXEC-E and `docs/concepts/ERRATA.md` ERRATA-002.
+
+### Known gaps
+
+- `In(<stateid>)` SCXML cross-region predicates are not yet in the admitted
+  subset (`docs/concepts/ERRATA.md` ERRATA-003); real infotainment control
+  cores (Skoda Bolero) require the normalized-form workaround until a future
+  release admits `In()`.
+
 ## 0.4.1 — 2026-05-28
 
 ### Changed

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scjson"
-version = "0.4.1"
+version = "0.4.2"
 description = "A JSON-based serialization of SCXML (State Chart XML) for modern tooling, interoperability, and education, with execution engine and trace tools for SCXML/SCML."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/py/scjson/context.py
+++ b/py/scjson/context.py
@@ -37,6 +37,11 @@ from .safe_eval import SafeExpressionEvaluator, SafeEvaluationError
 from .activation import ActivationRecord, TransitionSpec, ActivationStatus
 from .invoke import InvokeRegistry, InvokeHandler
 from . import dataclasses as dataclasses_module
+from .ecmascript_normalizer import (
+    ECMAScriptNormalizationError,
+    normalize as _normalize_ecmascript,
+    normalize_script as _normalize_ecmascript_script,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -421,8 +426,8 @@ class DocumentContext(BaseModel):
         dm_attr = getattr(doc, "datamodel_attribute", "null")
         if not dm_attr or dm_attr == "null":
             doc.datamodel_attribute = "python"
-        elif dm_attr != "python":
-            raise ValueError("Only the python datamodel is supported")
+        elif dm_attr not in ("python", "ecmascript"):
+            raise ValueError("Only the python and ecmascript datamodels are supported")
         raw_data = doc.model_dump(mode="python")
         raw_data["datamodel_attribute"] = doc.datamodel_attribute
 
@@ -451,12 +456,17 @@ class DocumentContext(BaseModel):
         parent: Optional[ActivationRecord],
         evaluator: SafeExpressionEvaluator,
         allow_unsafe_eval: bool,
+        ecmascript_mode: bool = False,
     ) -> ActivationRecord:
-        """Recursively create activations and collect datamodel entries."""
+        """Recursively create activations and collect datamodel entries.
 
-        # The Scxml root has no `id` attribute — its `name` is metadata, not an
+        When ``ecmascript_mode`` is ``True``, ``<data>`` expressions are
+        normalized through the ECMAScript normalizer before evaluation so that
+        JS literals evaluate correctly in Python (M1P6 D-M1P6-1).
+        """
+        # The Scxml root has no `id` attribute -- its `name` is metadata, not an
         # identifier, and using it as the activation id collides with state ids
-        # of the same value (e.g. <scxml name="menu">…<state id="menu"/></scxml>).
+        # of the same value (e.g. <scxml name="menu">...<state id="menu"/></scxml>).
         # The collision wipes the matching state from `_filter_states` outputs
         # because `_is_user_state` rejects anything == root_activation.id.
         if isinstance(node, Scxml):
@@ -465,7 +475,9 @@ class DocumentContext(BaseModel):
             ident = getattr(node, "id", None) or getattr(node, "name", None) or "anon"
         act = ActivationRecord(id=ident, node=node, parent=parent)
         act.local_data.update(
-            DocumentContext._extract_datamodel(node, evaluator, allow_unsafe_eval)
+            DocumentContext._extract_datamodel(
+                node, evaluator, allow_unsafe_eval, ecmascript_mode=ecmascript_mode
+            )
         )
 
         for t in getattr(node, "transition", []):
@@ -488,25 +500,29 @@ class DocumentContext(BaseModel):
         for child in getattr(node, "state", []):
             act.add_child(
                 DocumentContext._build_activation_tree(
-                    child, act, evaluator, allow_unsafe_eval
+                    child, act, evaluator, allow_unsafe_eval,
+                    ecmascript_mode=ecmascript_mode,
                 )
             )
         for child in getattr(node, "parallel", []):
             act.add_child(
                 DocumentContext._build_activation_tree(
-                    child, act, evaluator, allow_unsafe_eval
+                    child, act, evaluator, allow_unsafe_eval,
+                    ecmascript_mode=ecmascript_mode,
                 )
             )
         for child in getattr(node, "final", []):
             act.add_child(
                 DocumentContext._build_activation_tree(
-                    child, act, evaluator, allow_unsafe_eval
+                    child, act, evaluator, allow_unsafe_eval,
+                    ecmascript_mode=ecmascript_mode,
                 )
             )
         for child in getattr(node, "history", []):
             act.add_child(
                 DocumentContext._build_activation_tree(
-                    child, act, evaluator, allow_unsafe_eval
+                    child, act, evaluator, allow_unsafe_eval,
+                    ecmascript_mode=ecmascript_mode,
                 )
             )
         return act
@@ -516,8 +532,15 @@ class DocumentContext(BaseModel):
         node: SCXMLNode,
         evaluator: SafeExpressionEvaluator,
         allow_unsafe_eval: bool,
+        ecmascript_mode: bool = False,
     ) -> Dict[str, Any]:
-        """Return a dict mapping data IDs to values for *node*'s datamodel."""
+        """Return a dict mapping data IDs to values for *node*'s datamodel.
+
+        When ``ecmascript_mode`` is ``True``, ``data.expr`` values are first
+        normalized through the ECMAScript normalizer so that JS literals
+        (``true``, ``false``, ``null``, object/array expressions) evaluate
+        correctly in the Python sandbox (M1P6 D-M1P6-1).
+        """
         result: Dict[str, Any] = {}
         for dm in getattr(node, "datamodel", []):
             for data in dm.data:
@@ -525,7 +548,8 @@ class DocumentContext(BaseModel):
                 if data.expr is not None:
                     try:
                         value = DocumentContext._evaluate_static(
-                            data.expr, {}, evaluator, allow_unsafe_eval
+                            data.expr, {}, evaluator, allow_unsafe_eval,
+                            ecmascript_mode=ecmascript_mode,
                         )
                     except (SafeEvaluationError, Exception):
                         value = data.expr
@@ -545,9 +569,19 @@ class DocumentContext(BaseModel):
         env: Mapping[str, Any],
         evaluator: SafeExpressionEvaluator,
         allow_unsafe_eval: bool,
+        ecmascript_mode: bool = False,
     ) -> Any:
-        """Evaluate ``expr`` during context construction."""
+        """Evaluate ``expr`` during context construction.
 
+        When ``ecmascript_mode`` is ``True`` the expression is first normalized
+        from the admitted ECMAScript subset to Python via the
+        ``ecmascript_normalizer`` before evaluation (M1P6 D-M1P6-1).
+        """
+        if ecmascript_mode:
+            try:
+                expr = _normalize_ecmascript(expr)
+            except ECMAScriptNormalizationError:
+                pass  # let the evaluator handle (will produce an error value)
         if allow_unsafe_eval:
             return eval(expr, {}, dict(env))
         return evaluator.evaluate(expr, env)
@@ -971,7 +1005,78 @@ class DocumentContext(BaseModel):
             logger.warning("<cancel> could not find pending send with id '%s'", send_id)
 
     def _do_script(self, script: Any, act: ActivationRecord) -> None:
-        logger.warning("<script> execution is not yet implemented; skipping block")
+        """Execute a ``<script>`` block.
+
+        For the ``python`` datamodel, script execution is not yet implemented
+        and emits a warning.  For the ``ecmascript`` datamodel (M1P6 D-M1P6-2),
+        the script body is normalized from the admitted ECMAScript subset to
+        Python statements and then executed via ``exec()`` against the current
+        datamodel scope so that assignments to datamodel locations take effect.
+        """
+        if not getattr(self, "_ecmascript_mode", False):
+            logger.warning("<script> execution is not yet implemented; skipping block")
+            return
+
+        # Collect the script body from the script element.
+        # The pydantic schema wraps the text as: content=[{'content': ['text']}]
+        body: str = ""
+        if isinstance(script, str):
+            body = script
+        elif hasattr(script, "content") and script.content:
+            parts = []
+            def _extract_text(node):
+                if isinstance(node, str):
+                    parts.append(node)
+                elif isinstance(node, dict):
+                    for v in node.values():
+                        _extract_text(v)
+                elif isinstance(node, list):
+                    for item in node:
+                        _extract_text(item)
+            _extract_text(script.content)
+            body = "".join(parts)
+        if not body or not body.strip():
+            return
+
+        try:
+            py_body = _normalize_ecmascript_script(body)
+        except ECMAScriptNormalizationError as exc:
+            logger.warning(
+                "<script> body contains unsupported ECMAScript (%s): %s",
+                exc.diagnostic,
+                exc,
+            )
+            self._emit_error("error.execution", front=True)
+            return
+
+        # Build a mutable local namespace from the current scope so that
+        # assignments within the script propagate back to the datamodel.
+        env = self._scope_env(act)
+        local_ns = dict(env)
+        try:
+            exec(py_body, {}, local_ns)  # noqa: S102
+        except Exception as exc:
+            logger.warning("<script> execution failed: %s", exc)
+            self._emit_error("error.execution", front=True)
+            return
+
+        # Write back any variables that changed to their canonical location.
+        # We always write back dicts and lists because they may have been
+        # mutated in-place (e.g. t_INPUTS['key'] = val changes the dict
+        # without replacing the reference, so an identity check would miss it).
+        for varname, new_value in local_ns.items():
+            if varname.startswith("_") or varname == "In":
+                continue
+            old_value = env.get(varname)
+            changed = new_value is not old_value
+            if not changed and isinstance(new_value, (dict, list)):
+                # Mutable container: always write back in case of in-place mutation.
+                changed = True
+            if changed:
+                try:
+                    self._set_variable(varname, new_value, act)
+                except Exception:
+                    pass
 
     def _build_send_payload(self, send: Any, env: Dict[str, Any], act: ActivationRecord) -> Any:
         payload: Dict[str, Any] = {}
@@ -1587,8 +1692,19 @@ class DocumentContext(BaseModel):
         return env
 
     def _evaluate_expr(self, expr: str, env: Mapping[str, Any]) -> Any:
-        """Evaluate ``expr`` with the configured sandbox or raw ``eval``."""
+        """Evaluate ``expr`` with the configured sandbox or raw ``eval``.
 
+        When the machine uses ``datamodel="ecmascript"`` (M1P6 D-M1P6-1), the
+        expression is first normalized from the admitted ECMAScript subset to
+        Python via ``ecmascript_normalizer.normalize`` before evaluation.  Any
+        inadmissible form raises ``ECMAScriptNormalizationError`` which is
+        re-raised so callers can emit the appropriate ``error.execution`` event.
+        """
+        if getattr(self, "_ecmascript_mode", False):
+            try:
+                expr = _normalize_ecmascript(expr)
+            except ECMAScriptNormalizationError:
+                raise
         if self.allow_unsafe_eval:
             return eval(expr, {}, dict(env))
         return self.evaluator.evaluate(expr, env)
@@ -2063,7 +2179,12 @@ class DocumentContext(BaseModel):
     ) -> "DocumentContext":
         evaluator = evaluator or SafeExpressionEvaluator()
         lookup, path_map = cls._build_json_lookup(doc, raw_data)
-        root_state = cls._build_activation_tree(doc, None, evaluator, allow_unsafe_eval)
+        # Detect ecmascript datamodel before building the activation tree so
+        # that data expressions are normalized during construction.
+        _em_mode = getattr(doc, "datamodel_attribute", "python") == "ecmascript"
+        root_state = cls._build_activation_tree(
+            doc, None, evaluator, allow_unsafe_eval, ecmascript_mode=_em_mode
+        )
         ctx = cls(
             doc=doc,
             root_activation=root_state,
@@ -2077,6 +2198,8 @@ class DocumentContext(BaseModel):
         except Exception:
             ctx._base_dir = None
         ctx._action_cache = {}
+        # Record whether this machine uses the ecmascript datamodel (M1P6 D-M1P6-1).
+        ctx._ecmascript_mode = getattr(doc, "datamodel_attribute", "python") == "ecmascript"
         ctx.json_order = cls._build_order_map(raw_data, path_map, source_xml)
         ctx.data_model = root_state.local_data
         ctx._index_activations(root_state)

--- a/py/scjson/ecmascript_normalizer.py
+++ b/py/scjson/ecmascript_normalizer.py
@@ -1,0 +1,463 @@
+"""
+Agent Name: ecmascript-normalizer
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+Constrained ECMAScript expression front-end (M1P6 G2).
+
+Normalizes the admitted ECMAScript subset (D-M1P6-2) into Python expressions
+that can be evaluated by the existing Python sandbox evaluator.  Everything
+outside the admitted subset raises ECMAScriptNormalizationError with diagnostic
+name "unsupported-ecmascript" -- nothing is silently dropped.
+
+Admitted forms (D-M1P6-2):
+  Operators:   &&  ||  !  ===  !==  ==  !=  <  <=  >  >=  +  -  *  /  unary-
+  Literals:    true  false  null  undefined  number  string  array  object
+  Built-ins:   parseInt(x)  parseInt(x, r)  String(x)  Number(x)
+               <str>.replace(a, b)  (identical Python method -- passed through)
+  Sys vars:    _event  _event.name  _event.data  (available in eval env)
+  Member:      a.b  a[expr]
+  Script stmts (in <script>): assignment  if (cond) { ... }
+
+Inadmissible forms that produce unsupported-ecmascript:
+  =>  new  typeof  instanceof  for  while  do  switch  throw  try  catch
+  template literals (backtick)  delete  void  yield  await  class  import
+  export  with
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+
+# Sentinel prefix used to mark string-literal placeholders.  We use a
+# distinctive multi-character prefix that cannot appear in valid JS/Python
+# expressions so that restoring placeholders is unambiguous.
+_STR_SENTINEL = "__SCJSON_STR_"
+_STR_SENTINEL_RE = re.compile(r"__SCJSON_STR_(\d+)__")
+
+
+# ---------------------------------------------------------------------------
+# Error type
+# ---------------------------------------------------------------------------
+
+
+class ECMAScriptNormalizationError(ValueError):
+    """Raised when an expression or script body contains inadmissible forms.
+
+    :param message: Human-readable description of what was rejected.
+    :param diagnostic: Machine-readable diagnostic name per D-M1P6-8.
+        Always ``"unsupported-ecmascript"`` unless a sub-diagnostic is
+        warranted; callers MAY inspect this attribute.
+    """
+
+    diagnostic: str
+
+    def __init__(self, message: str, diagnostic: str = "unsupported-ecmascript") -> None:
+        super().__init__(message)
+        self.diagnostic = diagnostic
+
+
+# ---------------------------------------------------------------------------
+# Inadmissible-form detection patterns
+# ---------------------------------------------------------------------------
+
+_INADMISSIBLE_PATTERNS: List[Tuple[re.Pattern, str]] = [
+    # Arrow functions
+    (re.compile(r"=>"), "arrow function (=>)"),
+    # new keyword (word boundary)
+    (re.compile(r"\bnew\b"), "new expression"),
+    # typeof / instanceof
+    (re.compile(r"\btypeof\b"), "typeof operator"),
+    (re.compile(r"\binstanceof\b"), "instanceof operator"),
+    # Loops
+    (re.compile(r"\bfor\s*\("), "for loop"),
+    (re.compile(r"\bwhile\s*\("), "while loop"),
+    (re.compile(r"\bdo\s*\{"), "do-while loop"),
+    # switch / throw / try
+    (re.compile(r"\bswitch\s*\("), "switch statement"),
+    (re.compile(r"\bthrow\b"), "throw statement"),
+    (re.compile(r"\btry\s*\{"), "try statement"),
+    # delete / void / yield / await
+    (re.compile(r"\bdelete\b"), "delete operator"),
+    (re.compile(r"\bvoid\b"), "void operator"),
+    (re.compile(r"\byield\b"), "yield expression"),
+    (re.compile(r"\bawait\b"), "await expression"),
+    # class / import / export / with
+    (re.compile(r"\bclass\b"), "class declaration"),
+    (re.compile(r"\bimport\b"), "import statement"),
+    (re.compile(r"\bexport\b"), "export statement"),
+    (re.compile(r"\bwith\s*\("), "with statement"),
+    # Template literals (backtick strings)
+    (re.compile(r"`"), "template literal"),
+]
+
+
+# ---------------------------------------------------------------------------
+# String-literal extraction helpers
+# ---------------------------------------------------------------------------
+
+_STRING_LITERAL_RE = re.compile(
+    r"""(?P<sq>'(?:[^'\\]|\\.)*')|(?P<dq>"(?:[^"\\]|\\.)*")"""
+)
+
+_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _strip_comments(text: str) -> str:
+    """Remove // and /* ... */ comments from *text*."""
+    text = _BLOCK_COMMENT_RE.sub("", text)
+    text = _LINE_COMMENT_RE.sub("", text)
+    return text
+
+
+def _extract_strings(text: str) -> Tuple[str, List[str]]:
+    """Replace string literals with positional placeholders.
+
+    Returns (masked_text, strings) where ``strings[i]`` is the original
+    literal for placeholder ``__SCJSON_STR_i__``.
+    """
+    strings: List[str] = []
+
+    def _replace(m: re.Match) -> str:
+        idx = len(strings)
+        strings.append(m.group(0))
+        return "__SCJSON_STR_{}__".format(idx)
+
+    masked = _STRING_LITERAL_RE.sub(_replace, text)
+    return masked, strings
+
+
+def _restore_strings(text: str, strings: List[str]) -> str:
+    """Restore string placeholders back to their original literals."""
+
+    def _restore(m: re.Match) -> str:
+        return strings[int(m.group(1))]
+
+    return _STR_SENTINEL_RE.sub(_restore, text)
+
+
+def _is_str_placeholder(segment: str) -> bool:
+    """Return True when *segment* (stripped) is a string-literal placeholder."""
+    return bool(_STR_SENTINEL_RE.fullmatch(segment.strip()))
+
+
+# ---------------------------------------------------------------------------
+# Object-literal normalization (unquoted JS keys -> quoted Python dict keys)
+# ---------------------------------------------------------------------------
+
+_UNQUOTED_KEY_BRACE_RE = re.compile(r"\{([^{}]*)\}")
+_UNQUOTED_IDENTIFIER_KEY_RE = re.compile(
+    r"([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:"
+)
+
+
+def _normalize_object_literal(text: str) -> str:
+    """Convert JS-style ``{key: val}`` object literals to Python ``{"key": val}`` dicts.
+
+    Only rewrites unquoted identifier keys; already-quoted keys are left alone.
+    Applied to the *masked* text so string placeholders are safe.
+
+    :param text: Masked expression text.
+    :returns: Text with object literal keys quoted.
+    """
+
+    def _rewrite_obj(m: re.Match) -> str:
+        inner = m.group(1)
+        # Only quote identifier keys; skip string placeholders (already quoted
+        # string literals from _extract_strings) and already-quoted keys.
+        def _quote_key(km):
+            key_text = km.group(1)
+            # If the key is a string placeholder, leave it unquoted
+            # (it will be restored to its original quoted literal).
+            if key_text.startswith("__SCJSON_STR_"):
+                return km.group(0)
+            return '"{}":'.format(key_text)
+        rewritten = _UNQUOTED_IDENTIFIER_KEY_RE.sub(_quote_key, inner)
+        return "{" + rewritten + "}"
+
+    # Iteratively apply (inner-most first) until stable.
+    prev = None
+    while prev != text:
+        prev = text
+        text = _UNQUOTED_KEY_BRACE_RE.sub(_rewrite_obj, text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Token-level substitutions
+# ---------------------------------------------------------------------------
+
+
+def _apply_token_substitutions(text: str) -> str:
+    """Apply all operator and keyword token substitutions to *text*.
+
+    Operates on the *masked* text (string literals replaced with placeholders)
+    so that string content is never mutated.
+
+    :param text: Masked expression or script text.
+    :returns: Python-compatible text with ECMAScript tokens replaced.
+    """
+    # Strict equality/inequality must come before == / !=.
+    text = re.sub(r"===", "==", text)
+    text = re.sub(r"!==", "!=", text)
+
+    # Logical operators
+    text = re.sub(r"&&", " and ", text)
+    text = re.sub(r"\|\|", " or ", text)
+
+    # Logical not: !expr -> not expr
+    # ! not followed by = (after the !== -> != substitution above, any remaining
+    # ! is a logical not).
+    text = re.sub(r"!(?!=)", "not ", text)
+
+    # Boolean / null / undefined literals (word-boundary safe)
+    text = re.sub(r"\btrue\b", "True", text)
+    text = re.sub(r"\bfalse\b", "False", text)
+    text = re.sub(r"\bnull\b", "None", text)
+    text = re.sub(r"\bundefined\b", "None", text)
+
+    # parseInt(x) -> int(x),  parseInt(x, r) -> int(x, r)
+    text = re.sub(r"\bparseInt\b", "int", text)
+
+    # String(x) -> str(x)
+    text = re.sub(r"\bString\b(?=\s*\()", "str", text)
+
+    # Number(x) -> float(x)
+    text = re.sub(r"\bNumber\b(?=\s*\()", "float", text)
+
+    return text
+
+
+# ---------------------------------------------------------------------------
+# String concatenation coercion
+# ---------------------------------------------------------------------------
+
+
+def _coerce_string_concatenation(text: str, strings: List[str]) -> str:
+    """Wrap non-string operands of + with str() when adjacent to a string literal.
+
+    In ECMAScript ``42 + 'ms'`` coerces the integer to a string.  Python raises
+    ``TypeError``.  This pass wraps the non-string side in ``str()`` when one
+    operand of ``+`` is a known string placeholder.
+
+    :param text: Masked text (string literals replaced with placeholders).
+    :param strings: The original string literals from ``_extract_strings``.
+    :returns: Masked text with str() coercions applied where needed.
+    """
+    if not strings:
+        return text
+
+    _placeholder = r"__SCJSON_STR_\d+__"
+
+    # A "complex token" is a parenthesized expression, a dotted/subscripted
+    # identifier chain, a plain identifier, or an integer.
+    # We exclude ident tokens that are already str(...) calls to avoid
+    # double-wrapping (e.g. str(i_ID) -> str(str(i_ID))).
+    _complex_token = (
+        r"(?:"
+        r"str\([^)]*\)"                                       # already str(...)
+        r"|"
+        r"(?!str\s*\()[A-Za-z_][A-Za-z0-9_.]*(?:\[[^\]]*\])?"  # ident chain (not str()
+        r"|"
+        r"\([^)]*\)"                                           # (paren expr)
+        r"|"
+        r"\d+"                                                  # integer
+        r")"
+    )
+
+    def _needs_str_wrap(segment: str) -> bool:
+        s = segment.strip()
+        if _is_str_placeholder(s):
+            return False
+        if s.startswith("str("):
+            return False
+        return True
+
+    # Right-hand: PLACEHOLDER + complex_token
+    def _wrap_right(m: re.Match) -> str:
+        lhs = m.group(1)
+        rhs = m.group(2)
+        if _needs_str_wrap(rhs):
+            return "{} + str({})".format(lhs, rhs)
+        return m.group(0)
+
+    # Left-hand: complex_token + PLACEHOLDER
+    def _wrap_left(m: re.Match) -> str:
+        lhs = m.group(1)
+        rhs = m.group(2)
+        if _needs_str_wrap(lhs):
+            return "str({}) + {}".format(lhs, rhs)
+        return m.group(0)
+
+    # Apply: PLACEHOLDER + complex_token
+    text = re.sub(
+        r"({plh})\s*\+\s*({tok})".format(plh=_placeholder, tok=_complex_token),
+        _wrap_right,
+        text,
+    )
+    # Apply: complex_token + PLACEHOLDER
+    text = re.sub(
+        r"({tok})\s*\+\s*({plh})".format(tok=_complex_token, plh=_placeholder),
+        _wrap_left,
+        text,
+    )
+    # Remove any accidental double-wrapping: str(str(x)) -> str(x)
+    text = re.sub(r"str\(str\(", "str(", text)
+    # Remove any mangled "strstr(" that occurs when the ident "str" gets wrapped
+    text = re.sub(r"strstr\(", "str(", text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# if-statement normalization (script bodies only)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_if_statements(text: str) -> str:
+    """Convert ``if (cond) { ... }`` to Python ``if cond:\\n    ...`` form.
+
+    Handles the simple single-level if blocks that appear in the DP machine's
+    ``<script>`` elements.  Nested ifs are supported via recursive call on the
+    body.
+
+    :param text: Masked script body text.
+    :returns: Python-equivalent statement text.
+    """
+    result_parts: List[str] = []
+    i = 0
+    n = len(text)
+
+    while i < n:
+        m = re.search(r"\bif\s*\(", text[i:])
+        if m is None:
+            result_parts.append(text[i:])
+            break
+
+        start = i + m.start()
+        result_parts.append(text[i:start])
+
+        # Find the matching `)` for the condition
+        paren_start = i + m.end() - 1  # position of `(`
+        depth = 0
+        j = paren_start
+        while j < n:
+            if text[j] == "(":
+                depth += 1
+            elif text[j] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        cond = text[paren_start + 1:j]
+
+        # Skip whitespace after `)`
+        k = j + 1
+        while k < n and text[k] in " \t\r\n":
+            k += 1
+
+        if k < n and text[k] == "{":
+            # Find the matching `}`
+            brace_depth = 0
+            b = k
+            while b < n:
+                if text[b] == "{":
+                    brace_depth += 1
+                elif text[b] == "}":
+                    brace_depth -= 1
+                    if brace_depth == 0:
+                        break
+                b += 1
+            body = text[k + 1:b]
+            body_normalized = _normalize_if_statements(body)
+            # Dedent the body lines uniformly before re-indenting so that
+            # JS sources that use leading whitespace inside braces do not
+            # accumulate double-indentation in the output.
+            import textwrap as _textwrap
+            body_lines = _textwrap.dedent(body_normalized).strip().splitlines()
+            indented = "\n".join("    " + line for line in body_lines if line.strip())
+            result_parts.append("if {}:\n{}".format(cond.strip(), indented))
+            i = b + 1
+        else:
+            # Single statement on the same line (no braces)
+            eol = text.find("\n", k)
+            if eol == -1:
+                eol = n
+            stmt = text[k:eol].strip()
+            result_parts.append("if {}:\n    {}".format(cond.strip(), stmt))
+            i = eol
+
+    return "".join(result_parts)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def normalize(expr: str) -> str:
+    """Normalize an admitted ECMAScript expression to a Python expression.
+
+    :param expr: ECMAScript expression string from an SCXML ``cond``,
+        ``expr``, ``eventexpr``, ``targetexpr``, or ``delayexpr`` attribute.
+    :returns: A Python expression string suitable for ``eval()`` or the
+        scjson ``SafeExpressionEvaluator``.
+    :raises ECMAScriptNormalizationError: When *expr* contains a form outside
+        the admitted D-M1P6-2 subset.  The exception's ``.diagnostic``
+        attribute is always ``"unsupported-ecmascript"``.
+    """
+    cleaned = _strip_comments(expr)
+
+    # Check inadmissible forms before masking strings.
+    for pattern, description in _INADMISSIBLE_PATTERNS:
+        if pattern.search(cleaned):
+            raise ECMAScriptNormalizationError(
+                "ECMAScript form not in admitted subset (D-M1P6-2): {!r} "
+                "found in expression: {!r}".format(description, expr),
+                diagnostic="unsupported-ecmascript",
+            )
+
+    masked, strings = _extract_strings(cleaned)
+    masked = _normalize_object_literal(masked)
+    masked = _apply_token_substitutions(masked)
+    masked = _coerce_string_concatenation(masked, strings)
+    result = _restore_strings(masked, strings)
+    return result
+
+
+def normalize_script(script_body: str) -> str:
+    """Normalize an admitted ECMAScript ``<script>`` body to Python statements.
+
+    D-M1P6-2 admits only:
+    - Assignment to a datamodel location (incl. computed member: ``t[k] = v``).
+    - ``if (cond) { ... }`` whose body is itself admitted.
+
+    Everything else in a ``<script>`` body is ``forbidden`` per M0-D10 and
+    causes an ECMAScriptNormalizationError with diagnostic
+    ``"unsupported-ecmascript"``.
+
+    :param script_body: Raw JS ``<script>`` text.
+    :returns: Equivalent Python statement string.
+    :raises ECMAScriptNormalizationError: For inadmissible script forms.
+    """
+    cleaned = _strip_comments(script_body)
+
+    for pattern, description in _INADMISSIBLE_PATTERNS:
+        if pattern.search(cleaned):
+            raise ECMAScriptNormalizationError(
+                "ECMAScript form not in admitted subset (D-M1P6-2): {!r} "
+                "found in script body".format(description),
+                diagnostic="unsupported-ecmascript",
+            )
+
+    masked, strings = _extract_strings(cleaned)
+    masked = _normalize_object_literal(masked)
+    masked = _apply_token_substitutions(masked)
+    masked = _coerce_string_concatenation(masked, strings)
+    masked = _normalize_if_statements(masked)
+    result = _restore_strings(masked, strings)
+    return result

--- a/py/scjson/exec_ir.py
+++ b/py/scjson/exec_ir.py
@@ -1,0 +1,2006 @@
+"""
+Agent Name: exec-ir
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+M1 Executable IR + SCJSON-to-IR lowerer (M1P6 G2-codegen).
+
+This module provides:
+
+1. **Value model** (D-M1P6-3) -- a closed tagged union of runtime values:
+   Number, Str, Bool, Array, Map, Undefined.
+
+2. **ExpressionNode families** (M1-EXECUTABLE-IR Area 1 + D-M1P6-2) -- seven
+   families covering the admitted ECMAScript subset, lowered from Python AST
+   nodes produced by the ecmascript_normalizer.
+
+3. **ActionNode families** (M1-EXECUTABLE-IR Area 2, D-M1P6-4..6) -- seven
+   families: Assign, Log, Raise, Send (with dynamic expr slots), Cancel, If,
+   Foreach, plus CapabilityCall and the M1P6-added ForeachNode shape.
+
+4. **State-tree IR** -- recursive dataclasses mirroring the SCXML tree:
+   StateIR, ParallelIR, FinalIR, HistoryIR, MachineIR, TransitionIR,
+   DataSlotIR.
+
+5. **lower_document()** -- the public entry point: accepts a parsed ``Scxml``
+   Pydantic model and returns a ``MachineIR`` plus a list of
+   ``ExecutableDiagnostic`` items collected during lowering.  No construct is
+   silently dropped; unadmitted forms produce a diagnostic (D-M1P6-8).
+
+Mapping from admitted ECMAScript to ExpressionNode (D-M1P6-2):
+  JS form                     -> Python AST node      -> IR family
+  -----------------------------------------------------------------------
+  42  /  3.14  /  -5         -> ast.Constant(int|float) -> NumericLiteral
+  'hello'                    -> ast.Constant(str)     -> StringLiteral
+  True / False               -> ast.Constant(bool)    -> BoolLiteral
+  x  /  _event              -> ast.Name               -> VarRead
+  a.b  /  _event.name       -> ast.Attribute          -> MemberAccess
+  a[expr]                   -> ast.Subscript          -> IndexAccess
+  a + b  /  a == b  etc.    -> ast.BinOp / ast.Compare -> BinOp
+  !x  (normalized to not x) -> ast.UnaryOp(Not)       -> UnaryOp
+  -x                        -> ast.UnaryOp(USub)       -> UnaryOp
+  parseInt(x)  String(x) .. -> ast.Call               -> CallNode
+  [1, 2, 3]                 -> ast.List               -> ArrayLiteral
+  {a: b}                    -> ast.Dict               -> MapLiteral
+
+Deviations from M1-EXECUTABLE-IR spec (none; full compliance):
+  - M1P1 seven ExpressionNode families are all implemented.
+  - M1P2 seven ActionNode families are all implemented.
+  - M1P6 ForeachNode, inline-invoke nested MachineIR, dynamic Send slots
+    are implemented per D-M1P6-4, D-M1P6-5, D-M1P6-6.
+  - CapabilityCallNode: script elements map to CapabilityCallNode per M1P3;
+    name synthesis follows the frozen pattern.
+  - Diagnostics are collected (never raised) per D-M1P6-8.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExecutableDiagnostic:
+    """A non-fatal lowering diagnostic (M1P4 / D-M1P6-8).
+
+    Diagnostics are always collected; they never abort lowering.
+
+    :param code: Machine-readable code, e.g. ``"unsupported-ecmascript"``.
+    :param outcome: One of ``"accept"``, ``"normalize"``, ``"capability-only"``,
+        ``"reject"``.
+    :param tier: Portability tier of the offending construct.
+    :param source_origin: Free-form origin label (state id / block type).
+    :param message: Human-readable description.
+    """
+
+    code: str
+    outcome: str
+    tier: str
+    source_origin: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Value model (D-M1P6-3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NumberValue:
+    """A numeric IR value (int or float).
+
+    :param v: The numeric value.
+    """
+
+    v: Union[int, float]
+
+
+@dataclass
+class StrValue:
+    """A string IR value.
+
+    :param v: The string value.
+    """
+
+    v: str
+
+
+@dataclass
+class BoolValue:
+    """A boolean IR value.
+
+    :param v: The boolean value.
+    """
+
+    v: bool
+
+
+@dataclass
+class ArrayValue:
+    """An array IR value (ordered sequence).
+
+    :param items: Sequence of element values.
+    """
+
+    items: List["Value"] = field(default_factory=list)
+
+
+@dataclass
+class MapValue:
+    """A string-keyed map IR value (ordered).
+
+    :param entries: Ordered list of (key, value) pairs.
+    """
+
+    entries: List[tuple] = field(default_factory=list)
+
+
+@dataclass
+class UndefinedValue:
+    """Undefined / null sentinel (compares falsey per D-M1P6-3)."""
+
+
+#: Tagged union of all admitted IR values.
+Value = Union[NumberValue, StrValue, BoolValue, ArrayValue, MapValue, UndefinedValue]
+
+
+# ---------------------------------------------------------------------------
+# ExpressionNode families (M1-EXECUTABLE-IR Area 1, D-M1P6-2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NumericLiteral:
+    """Numeric constant.  Ref: M1-EXECUTABLE-IR Area 1, ``{"num": float}``.
+
+    :param num: The numeric constant value.
+    :param diagnostic: Optional diagnostic if this node carries a warning.
+    """
+
+    num: Union[int, float]
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class StringLiteral:
+    """String constant.  Ref: M1-EXECUTABLE-IR Area 1, ``{"str": str}``.
+
+    :param s: The string value.
+    :param diagnostic: Optional diagnostic if this node carries a warning.
+    """
+
+    s: str
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class BoolLiteral:
+    """Boolean constant.  Ref: M1-EXECUTABLE-IR Area 1, ``{"bool": bool}``.
+
+    :param b: The boolean value.
+    :param diagnostic: Optional diagnostic if this node carries a warning.
+    """
+
+    b: bool
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class VarRead:
+    """Read a datamodel variable.  Ref: M1-EXECUTABLE-IR Area 1, ``{"var": str}``.
+
+    Type is ``unknown`` at M1; deferred to M2.
+
+    :param var: Variable name.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    var: str
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class MemberAccess:
+    """Static attribute access (``a.b``).
+
+    Extension of the M1 ExpressionNode family for the admitted ECMAScript subset
+    (D-M1P6-2): ``_event.name``, ``_event.data``, etc.
+
+    :param obj: Object expression.
+    :param attr: Attribute name.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    obj: "ExpressionNode"
+    attr: str
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class IndexAccess:
+    """Computed index access (``a[expr]``).
+
+    Covers ``t_INPUTS[_event.name]``, ``t_HAND_COMPLIANCE[i][0]``, etc.
+    (D-M1P6-2).
+
+    :param obj: Object (array/map) expression.
+    :param index: Index expression.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    obj: "ExpressionNode"
+    index: "ExpressionNode"
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class BinOp:
+    """Binary or comparison operation.
+
+    Covers ``+  -  *  /  ==  !=  <  <=  >  >=  &&  ||``
+    (M1-EXECUTABLE-IR ``Comparison`` / ``BoolCompose`` extended with arithmetic).
+
+    :param op: Operator string from the admitted set.
+    :param lhs: Left operand.
+    :param rhs: Right operand.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    op: str
+    lhs: "ExpressionNode"
+    rhs: "ExpressionNode"
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class UnaryOp:
+    """Unary operation (``!`` / unary ``-``).
+
+    Covers M1-EXECUTABLE-IR ``Not``; extended with unary minus for arithmetic.
+
+    :param op: ``"not"`` or ``"neg"``.
+    :param operand: Operand expression.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    op: str  # "not" | "neg"
+    operand: "ExpressionNode"
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class CallNode:
+    """Admitted built-in call (``parseInt``, ``String``, ``Number``, ``.replace``).
+
+    D-M1P6-2 whitelist only; any other call produces ``unsupported-ecmascript``.
+
+    :param func: Canonical function name (e.g. ``"parseInt"``, ``"str"``,
+        ``"float"``, ``"replace"``).
+    :param args: Argument expression list.
+    :param receiver: For method calls (``<str>.replace(a, b)``), the receiver
+        expression; ``None`` for free functions.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    func: str
+    args: List["ExpressionNode"] = field(default_factory=list)
+    receiver: Optional["ExpressionNode"] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class ArrayLiteral:
+    """Array literal (``[a, b, c]``), including array-of-array.
+
+    :param items: Element expressions.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    items: List["ExpressionNode"] = field(default_factory=list)
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class MapLiteral:
+    """Object literal (``{key: val, ...}``).
+
+    Keys must be string literals or string-placeholder identifiers per
+    the normalizer's object-literal rewriting.
+
+    :param entries: List of (key_expr, value_expr) pairs.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    entries: List[tuple] = field(default_factory=list)
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class UnsupportedExpr:
+    """Placeholder for an expression that could not be lowered.
+
+    Carries the diagnostic and the original source text so downstream
+    consumers can report the failure location.  Tier: ``unsupported``.
+    Per D-M1P6-8 this must never be silently omitted.
+
+    :param source: Original source text.
+    :param diagnostic: Required diagnostic entry.
+    """
+
+    source: str
+    diagnostic: ExecutableDiagnostic
+
+
+#: Union of all admitted ExpressionNode types.
+ExpressionNode = Union[
+    NumericLiteral,
+    StringLiteral,
+    BoolLiteral,
+    VarRead,
+    MemberAccess,
+    IndexAccess,
+    BinOp,
+    UnaryOp,
+    CallNode,
+    ArrayLiteral,
+    MapLiteral,
+    UnsupportedExpr,
+]
+
+
+# ---------------------------------------------------------------------------
+# OriginRef (M1-EXECUTABLE-IR Area 2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OriginRef:
+    """Block-level source origin annotation.
+
+    :param type: Block kind: ``"onentry"``, ``"onexit"``, ``"transition"``,
+        ``"script"``.
+    :param state: Owning state id if known.
+    :param idx: Index within the containing block list.
+    :param src: Source state id for transitions.
+    :param dst: Target state id(s) for transitions.
+    """
+
+    type: str
+    state: Optional[str] = None
+    idx: Optional[int] = None
+    src: Optional[str] = None
+    dst: Optional[List[str]] = None
+
+
+# ---------------------------------------------------------------------------
+# ActionNode families (M1-EXECUTABLE-IR Area 2, D-M1P6-4..6)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AssignNode:
+    """Assign to a datamodel location.  M1-EXECUTABLE-IR ``AssignNode``.
+
+    :param loc: Target location (variable name, or ``"map[key]"`` for
+        computed-member assignment).
+    :param expr: Value expression.
+    :param op: Assignment operator: ``"set"`` | ``"add"`` | ``"sub"`` |
+        ``"mul"`` | ``"div"``.
+    :param origin: Block-level origin reference.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    loc: str
+    expr: ExpressionNode
+    op: str = "set"
+    origin: Optional[OriginRef] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class LogNode:
+    """Log a value.  M1-EXECUTABLE-IR ``LogNode``.
+
+    :param expr: Expression to log.
+    :param label: Optional label string.
+    :param origin: Block-level origin reference.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    expr: ExpressionNode
+    label: Optional[str] = None
+    origin: Optional[OriginRef] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class RaiseNode:
+    """Raise a named event.  M1-EXECUTABLE-IR ``RaiseNode``.
+
+    :param event: Event name string.
+    :param origin: Block-level origin reference.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    event: str
+    origin: Optional[OriginRef] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class SendNode:
+    """Send an event.  M1-EXECUTABLE-IR ``SendNode`` with D-M1P6-6 dynamic slots.
+
+    Static ``event`` / ``target`` / ``delay`` are plain strings; dynamic
+    ``eventexpr`` / ``targetexpr`` / ``delayexpr`` / ``content_expr`` hold
+    ``ExpressionNode`` trees evaluated at send time.
+
+    :param event: Static event name (or ``None`` when ``eventexpr`` is set).
+    :param eventexpr: Dynamic event-name expression (D-M1P6-6).
+    :param target: Static send target (or ``None``).
+    :param targetexpr: Dynamic target expression (D-M1P6-6).
+    :param delay: Static delay string (or ``None``).
+    :param delayexpr: Dynamic delay expression (D-M1P6-6).
+    :param send_id: Static send identifier.
+    :param content_expr: Dynamic ``<content expr=...>`` expression.
+    :param params: List of ``(name, expr)`` pairs from ``<param>`` children.
+    :param origin: Block-level origin reference.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    event: Optional[str] = None
+    eventexpr: Optional[ExpressionNode] = None
+    target: Optional[str] = None
+    targetexpr: Optional[ExpressionNode] = None
+    delay: Optional[str] = None
+    delayexpr: Optional[ExpressionNode] = None
+    send_id: Optional[str] = None
+    content_expr: Optional[ExpressionNode] = None
+    params: List[tuple] = field(default_factory=list)
+    origin: Optional[OriginRef] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class CancelNode:
+    """Cancel a pending send.  M1-EXECUTABLE-IR ``CancelNode`` (stub).
+
+    :param sendid: Static send id to cancel.
+    :param origin: Block-level origin reference.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    sendid: Optional[str] = None
+    origin: Optional[OriginRef] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class IfBranch:
+    """One branch of an IfNode.
+
+    :param guard: Guard expression (``None`` for ``else`` branches).
+    :param body: Action list for this branch.
+    """
+
+    guard: Optional[ExpressionNode]
+    body: List["ActionNode"] = field(default_factory=list)
+
+
+@dataclass
+class IfNode:
+    """Conditional action.  M1-EXECUTABLE-IR ``IfNode``.
+
+    Branches are tested in order; first match fires.
+
+    :param branches: Ordered list of branches (if / elseif / else).
+    :param origin: Block-level origin reference.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    branches: List[IfBranch] = field(default_factory=list)
+    origin: Optional[OriginRef] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class ForeachNode:
+    """Bounded iteration over an array.  D-M1P6-4.
+
+    :param array_expr: Expression evaluating to an Array value.
+    :param item: Name of the item binding variable.
+    :param index: Optional name of the index binding variable.
+    :param body: Actions executed per iteration.
+    :param depth: Nesting depth (max 4 per D-M1P6-4).
+    :param origin: Block-level origin reference.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    array_expr: ExpressionNode
+    item: str
+    index: Optional[str] = None
+    body: List["ActionNode"] = field(default_factory=list)
+    depth: int = 1
+    origin: Optional[OriginRef] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class CapabilityCallNode:
+    """Named or synthesized capability call.  M1-EXECUTABLE-IR Area 3.
+
+    :param name: Stable capability identifier (named or synthesized).
+    :param origin: Block-level source reference.
+    :param success_event: ``"<name>.success"`` -- frozen at M1.
+    :param error_event: ``"<name>.error"`` -- frozen at M1.
+    :param capability_intent: ``None`` at M1; typed at M2.
+    :param args: ``None`` at M1; typed at M2.
+    :param return_type: ``None`` at M1; typed at M2.
+    :param correlation_id: ``None`` at M1; runtime token at M4.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    name: str
+    origin: OriginRef
+    success_event: str
+    error_event: str
+    capability_intent: None = None
+    args: None = None
+    return_type: None = None
+    correlation_id: None = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+#: Union of all ActionNode types.
+ActionNode = Union[
+    AssignNode,
+    LogNode,
+    RaiseNode,
+    SendNode,
+    CancelNode,
+    IfNode,
+    ForeachNode,
+    CapabilityCallNode,
+]
+
+
+# ---------------------------------------------------------------------------
+# State-tree IR
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DataSlotIR:
+    """One ``<data>`` element in a ``<datamodel>``.
+
+    :param id: Data slot identifier.
+    :param initial_value: IR-level initial value (or ``None`` for unspecified).
+    :param expr_source: Original expression source text.
+    :param diagnostic: Optional diagnostic.
+    """
+
+    id: str
+    initial_value: Optional[Value] = None
+    expr_source: Optional[str] = None
+    diagnostic: Optional[ExecutableDiagnostic] = None
+
+
+@dataclass
+class TransitionIR:
+    """One transition in the IR.
+
+    :param event: Event pattern (``None`` for eventless/epsilon transitions).
+    :param targets: List of target state ids.
+    :param guard: Guard expression (``None`` means always enabled).
+    :param actions: Executable content in document order.
+    :param origin: Block-level origin reference.
+    :param diagnostics: Per-transition diagnostic list.
+    """
+
+    event: Optional[str] = None
+    targets: List[str] = field(default_factory=list)
+    guard: Optional[ExpressionNode] = None
+    actions: List[ActionNode] = field(default_factory=list)
+    origin: Optional[OriginRef] = None
+    diagnostics: List[ExecutableDiagnostic] = field(default_factory=list)
+
+
+@dataclass
+class StateIR:
+    """IR for a ``<state>`` element.
+
+    :param id: State identifier.
+    :param initial: Initial sub-state id (or ``None``).
+    :param datamodel: Data slots declared on this state.
+    :param onentry: Onentry action list.
+    :param onexit: Onexit action list.
+    :param transitions: Ordered transition list.
+    :param children: Child StateIR / ParallelIR / FinalIR / HistoryIR nodes.
+    :param invokes: Invoke IR nodes attached to this state.
+    :param diagnostics: Diagnostics collected for this state.
+    """
+
+    id: str
+    initial: Optional[str] = None
+    datamodel: List[DataSlotIR] = field(default_factory=list)
+    onentry: List[ActionNode] = field(default_factory=list)
+    onexit: List[ActionNode] = field(default_factory=list)
+    transitions: List[TransitionIR] = field(default_factory=list)
+    children: List["AnyStateIR"] = field(default_factory=list)
+    invokes: List["InvokeIR"] = field(default_factory=list)
+    diagnostics: List[ExecutableDiagnostic] = field(default_factory=list)
+
+
+@dataclass
+class ParallelIR:
+    """IR for a ``<parallel>`` element.
+
+    :param id: Parallel region identifier.
+    :param datamodel: Data slots declared on this region.
+    :param onentry: Onentry action list.
+    :param onexit: Onexit action list.
+    :param transitions: Ordered transition list.
+    :param children: Child region / state nodes (all run concurrently).
+    :param invokes: Invoke IR nodes.
+    :param diagnostics: Diagnostics collected for this region.
+    """
+
+    id: str
+    datamodel: List[DataSlotIR] = field(default_factory=list)
+    onentry: List[ActionNode] = field(default_factory=list)
+    onexit: List[ActionNode] = field(default_factory=list)
+    transitions: List[TransitionIR] = field(default_factory=list)
+    children: List["AnyStateIR"] = field(default_factory=list)
+    invokes: List["InvokeIR"] = field(default_factory=list)
+    diagnostics: List[ExecutableDiagnostic] = field(default_factory=list)
+
+
+@dataclass
+class FinalIR:
+    """IR for a ``<final>`` element.
+
+    :param id: Final state identifier.
+    :param diagnostics: Diagnostics collected for this state.
+    """
+
+    id: str
+    diagnostics: List[ExecutableDiagnostic] = field(default_factory=list)
+
+
+@dataclass
+class HistoryIR:
+    """IR for a ``<history>`` pseudostate.
+
+    :param id: History pseudostate identifier.
+    :param type: ``"shallow"`` or ``"deep"``.
+    :param diagnostics: Diagnostics collected for this element.
+    """
+
+    id: str
+    type: str = "shallow"
+    diagnostics: List[ExecutableDiagnostic] = field(default_factory=list)
+
+
+#: Union of all state-level IR node types.
+AnyStateIR = Union[StateIR, ParallelIR, FinalIR, HistoryIR]
+
+
+@dataclass
+class InvokeIR:
+    """IR for an ``<invoke>`` element.
+
+    :param invoke_id: Explicit invoke id (or ``None`` for auto-assigned).
+    :param type_value: Invoke type string (default ``"scxml"``).
+    :param src: External source URI (``None`` for inline content).
+    :param child_machine: Nested MachineIR for inline ``<content><scxml>``,
+        depth-bounded per D-M1P6-5.
+    :param params: List of ``(name, expr)`` pairs from ``<param>`` children.
+    :param autoforward: Whether to autoforward events.
+    :param depth: Nesting depth of this invocation (max 2 per D-M1P6-5).
+    :param diagnostics: Diagnostics collected for this invoke.
+    """
+
+    invoke_id: Optional[str] = None
+    type_value: str = "scxml"
+    src: Optional[str] = None
+    child_machine: Optional["MachineIR"] = None
+    params: List[tuple] = field(default_factory=list)
+    autoforward: bool = False
+    depth: int = 1
+    diagnostics: List[ExecutableDiagnostic] = field(default_factory=list)
+
+
+@dataclass
+class MachineIR:
+    """Top-level IR for one SCXML document.
+
+    :param name: Machine name from ``<scxml name=...>``.
+    :param datamodel_attr: Datamodel attribute (``"ecmascript"`` | ``"python"``
+        | ``"null"``).
+    :param initial: Initial state id(s).
+    :param datamodel: Root-level data slots.
+    :param children: Top-level state / parallel / final nodes.
+    :param diagnostics: All diagnostics collected during lowering of this
+        machine (does not include child-machine diagnostics).
+    """
+
+    name: Optional[str] = None
+    datamodel_attr: str = "null"
+    initial: List[str] = field(default_factory=list)
+    datamodel: List[DataSlotIR] = field(default_factory=list)
+    children: List[AnyStateIR] = field(default_factory=list)
+    diagnostics: List[ExecutableDiagnostic] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Python-AST → ExpressionNode converter
+# ---------------------------------------------------------------------------
+
+_ADMITTED_BUILTINS = frozenset({"int", "str", "float"})
+_ADMITTED_METHODS = frozenset({"replace"})
+
+# Maps Python AST operator types to canonical IR op strings.
+_BINOP_MAP: Dict[type, str] = {
+    ast.Add: "+",
+    ast.Sub: "-",
+    ast.Mult: "*",
+    ast.Div: "/",
+    ast.BitOr: "|",
+    ast.BitAnd: "&",
+}
+_CMPOP_MAP: Dict[type, str] = {
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+}
+_BOOLOP_MAP: Dict[type, str] = {
+    ast.And: "&&",
+    ast.Or: "||",
+}
+
+
+def _ast_to_expr(node: ast.expr, origin: str) -> ExpressionNode:
+    """Convert a Python AST expression node to an IR ExpressionNode.
+
+    :param node: Python AST expression node produced by ``ast.parse``.
+    :param origin: Source-origin label (state id / block type) for diagnostics.
+    :returns: An ExpressionNode; never raises; unsupported forms return
+        ``UnsupportedExpr`` with a diagnostic.
+    """
+    # Constant
+    if isinstance(node, ast.Constant):
+        v = node.value
+        if v is None:
+            return UndefinedValue()  # type: ignore[return-value]
+        if isinstance(v, bool):
+            return BoolLiteral(b=v)
+        if isinstance(v, (int, float)):
+            return NumericLiteral(num=v)
+        if isinstance(v, str):
+            return StringLiteral(s=v)
+        return _unsupported_expr(
+            ast.unparse(node), origin,
+            "unsupported constant type: {}".format(type(v).__name__),
+        )
+
+    # Name (variable read)
+    if isinstance(node, ast.Name):
+        return VarRead(var=node.id)
+
+    # Attribute access (a.b)
+    if isinstance(node, ast.Attribute):
+        obj = _ast_to_expr(node.value, origin)
+        return MemberAccess(obj=obj, attr=node.attr)
+
+    # Subscript (a[expr])
+    if isinstance(node, ast.Subscript):
+        obj = _ast_to_expr(node.value, origin)
+        # Python 3.9+ wraps the index in an Index node; 3.9+ uses the value directly.
+        idx_node = node.slice
+        if isinstance(idx_node, ast.Index):  # type: ignore[attr-defined]
+            idx_node = idx_node.value  # type: ignore[attr-defined]
+        idx = _ast_to_expr(idx_node, origin)
+        return IndexAccess(obj=obj, index=idx)
+
+    # BinOp (arithmetic)
+    if isinstance(node, ast.BinOp):
+        op_str = _BINOP_MAP.get(type(node.op))
+        if op_str is None:
+            return _unsupported_expr(
+                ast.unparse(node), origin,
+                "unsupported binary operator: {}".format(type(node.op).__name__),
+            )
+        lhs = _ast_to_expr(node.left, origin)
+        rhs = _ast_to_expr(node.right, origin)
+        return BinOp(op=op_str, lhs=lhs, rhs=rhs)
+
+    # Compare (a == b, a < b, etc.)
+    if isinstance(node, ast.Compare):
+        if len(node.ops) != 1 or len(node.comparators) != 1:
+            # Chained comparisons not in admitted subset
+            return _unsupported_expr(
+                ast.unparse(node), origin,
+                "chained comparison not in admitted subset",
+            )
+        op_str = _CMPOP_MAP.get(type(node.ops[0]))
+        if op_str is None:
+            return _unsupported_expr(
+                ast.unparse(node), origin,
+                "unsupported comparison operator: {}".format(type(node.ops[0]).__name__),
+            )
+        lhs = _ast_to_expr(node.left, origin)
+        rhs = _ast_to_expr(node.comparators[0], origin)
+        return BinOp(op=op_str, lhs=lhs, rhs=rhs)
+
+    # BoolOp (and / or)
+    if isinstance(node, ast.BoolOp):
+        op_str = _BOOLOP_MAP.get(type(node.op))
+        if op_str is None:
+            return _unsupported_expr(
+                ast.unparse(node), origin,
+                "unsupported boolean operator: {}".format(type(node.op).__name__),
+            )
+        # Fold left-associatively
+        result = _ast_to_expr(node.values[0], origin)
+        for val in node.values[1:]:
+            result = BinOp(op=op_str, lhs=result, rhs=_ast_to_expr(val, origin))
+        return result
+
+    # UnaryOp (not / -)
+    if isinstance(node, ast.UnaryOp):
+        if isinstance(node.op, ast.Not):
+            operand = _ast_to_expr(node.operand, origin)
+            return UnaryOp(op="not", operand=operand)
+        if isinstance(node.op, ast.USub):
+            operand = _ast_to_expr(node.operand, origin)
+            return UnaryOp(op="neg", operand=operand)
+        return _unsupported_expr(
+            ast.unparse(node), origin,
+            "unsupported unary operator: {}".format(type(node.op).__name__),
+        )
+
+    # Call (free function or method)
+    if isinstance(node, ast.Call):
+        # Free function calls: int(), str(), float()
+        if isinstance(node.func, ast.Name):
+            fname = node.func.id
+            if fname in _ADMITTED_BUILTINS:
+                args = [_ast_to_expr(a, origin) for a in node.args]
+                return CallNode(func=fname, args=args)
+            return _unsupported_expr(
+                ast.unparse(node), origin,
+                "non-admitted free function call: {}".format(fname),
+            )
+        # Method calls: <str>.replace(a, b)
+        if isinstance(node.func, ast.Attribute):
+            mname = node.func.attr
+            if mname in _ADMITTED_METHODS:
+                receiver = _ast_to_expr(node.func.value, origin)
+                args = [_ast_to_expr(a, origin) for a in node.args]
+                return CallNode(func=mname, args=args, receiver=receiver)
+            return _unsupported_expr(
+                ast.unparse(node), origin,
+                "non-admitted method call: {}".format(mname),
+            )
+        return _unsupported_expr(
+            ast.unparse(node), origin,
+            "unsupported call form",
+        )
+
+    # List literal ([a, b, c])
+    if isinstance(node, ast.List):
+        items = [_ast_to_expr(elt, origin) for elt in node.elts]
+        return ArrayLiteral(items=items)
+
+    # Dict literal ({k: v, ...})
+    if isinstance(node, ast.Dict):
+        entries = []
+        for k, v in zip(node.keys, node.values):
+            if k is None:
+                return _unsupported_expr(
+                    ast.unparse(node), origin,
+                    "dict unpacking (**) not in admitted subset",
+                )
+            key_expr = _ast_to_expr(k, origin)
+            val_expr = _ast_to_expr(v, origin)
+            entries.append((key_expr, val_expr))
+        return MapLiteral(entries=entries)
+
+    # Tuple (not admitted)
+    return _unsupported_expr(
+        ast.unparse(node) if hasattr(ast, "unparse") else repr(node),
+        origin,
+        "unsupported expression form: {}".format(type(node).__name__),
+    )
+
+
+def _unsupported_expr(source: str, origin: str, message: str) -> UnsupportedExpr:
+    """Build an UnsupportedExpr placeholder with a diagnostic.
+
+    :param source: Source text of the expression.
+    :param origin: State/block origin for diagnostic attribution.
+    :param message: Human-readable description of the failure.
+    :returns: UnsupportedExpr with a ``"unsupported-ecmascript"`` diagnostic.
+    """
+    diag = ExecutableDiagnostic(
+        code="unsupported-ecmascript",
+        outcome="reject",
+        tier="forbidden",
+        source_origin=origin,
+        message=message,
+    )
+    return UnsupportedExpr(source=source, diagnostic=diag)
+
+
+def lower_expression(expr_str: str, origin: str) -> tuple:
+    """Lower an ECMAScript expression string to an ExpressionNode.
+
+    Uses the ecmascript_normalizer to translate to Python, then parses the
+    Python AST and converts to the IR.
+
+    :param expr_str: Raw ECMAScript expression string.
+    :param origin: Source origin label for diagnostics.
+    :returns: ``(ExpressionNode, diagnostics)`` where ``diagnostics`` is a
+        (possibly empty) list of ``ExecutableDiagnostic`` items.  Never raises.
+    """
+    from .ecmascript_normalizer import (
+        ECMAScriptNormalizationError,
+        normalize as _normalize,
+    )
+
+    diagnostics: List[ExecutableDiagnostic] = []
+    if not expr_str or not expr_str.strip():
+        diag = ExecutableDiagnostic(
+            code="empty-expression",
+            outcome="normalize",
+            tier="restricted",
+            source_origin=origin,
+            message="Empty expression string",
+        )
+        diagnostics.append(diag)
+        return UnsupportedExpr(source=expr_str, diagnostic=diag), diagnostics
+
+    try:
+        py_expr = _normalize(expr_str)
+    except ECMAScriptNormalizationError as exc:
+        diag = ExecutableDiagnostic(
+            code=getattr(exc, "diagnostic", "unsupported-ecmascript"),
+            outcome="reject",
+            tier="forbidden",
+            source_origin=origin,
+            message=str(exc),
+        )
+        diagnostics.append(diag)
+        return UnsupportedExpr(source=expr_str, diagnostic=diag), diagnostics
+
+    try:
+        tree = ast.parse(py_expr, mode="eval")
+    except SyntaxError as exc:
+        diag = ExecutableDiagnostic(
+            code="parse-error",
+            outcome="reject",
+            tier="forbidden",
+            source_origin=origin,
+            message="Python AST parse error after normalization: {} (normalized: {!r})".format(
+                exc, py_expr
+            ),
+        )
+        diagnostics.append(diag)
+        return UnsupportedExpr(source=expr_str, diagnostic=diag), diagnostics
+
+    ir_node = _ast_to_expr(tree.body, origin)
+    if isinstance(ir_node, UnsupportedExpr):
+        diagnostics.append(ir_node.diagnostic)
+    return ir_node, diagnostics
+
+
+# ---------------------------------------------------------------------------
+# SCJSON → IR lowerer
+# ---------------------------------------------------------------------------
+
+
+class _LoweringContext:
+    """Mutable context accumulating diagnostics during lowering.
+
+    :param ecmascript_mode: True when the machine's datamodel is
+        ``"ecmascript"``.
+    :param invoke_depth: Current invocation nesting depth (max 2 per D-M1P6-5).
+    """
+
+    def __init__(self, *, ecmascript_mode: bool = False, invoke_depth: int = 0) -> None:
+        self.ecmascript_mode = ecmascript_mode
+        self.invoke_depth = invoke_depth
+        self.diagnostics: List[ExecutableDiagnostic] = []
+        # Counters used for capability-call name synthesis (M1P3)
+        self._cap_counters: Dict[str, int] = {}
+
+    def push_diag(self, diag: ExecutableDiagnostic) -> None:
+        """Append a diagnostic.
+
+        :param diag: The diagnostic to record.
+        """
+        self.diagnostics.append(diag)
+
+    def lower_expr(self, expr_str: str, origin: str) -> ExpressionNode:
+        """Lower an expression string to an ExpressionNode, collecting diagnostics.
+
+        If the machine is NOT in ECMAScript mode, treat the expression as a
+        Python-datamodel expression and emit a lightweight VarRead or
+        UnsupportedExpr rather than running the JS normalizer.
+
+        :param expr_str: Expression source text.
+        :param origin: Source origin label.
+        :returns: ExpressionNode (never raises).
+        """
+        if self.ecmascript_mode:
+            node, diags = lower_expression(expr_str, origin)
+            self.diagnostics.extend(diags)
+            return node
+        # Python-datamodel: do a best-effort lowering via the Python AST
+        # directly (no ECMAScript normalizer needed).
+        node, diags = _lower_python_expr(expr_str, origin)
+        self.diagnostics.extend(diags)
+        return node
+
+    def synth_cap_name(
+        self, *, script_name: Optional[str], block_type: str, state: str, idx: int
+    ) -> str:
+        """Synthesize a stable CapabilityCallNode name per M1P3.
+
+        Named scripts use their own name.  Unnamed scripts get the frozen
+        synthesis pattern: ``script_<block_type>_<state>_<count>``.
+
+        :param script_name: Explicit script name attribute (or ``None``).
+        :param block_type: ``"onentry"``, ``"onexit"``, or ``"trans_<src>_<dst>"``.
+        :param state: Owning state id.
+        :param idx: Index within the block.
+        :returns: Synthesized stable name string.
+        """
+        if script_name:
+            return script_name
+        key = "{}_{}".format(block_type, state)
+        count = self._cap_counters.get(key, 0)
+        self._cap_counters[key] = count + 1
+        return "script_{}_{}_{}_{}".format(block_type, state, idx, count)
+
+
+def _lower_python_expr(expr_str: str, origin: str) -> tuple:
+    """Best-effort Python-datamodel expression lowering.
+
+    Parses the expression as Python directly (no JS normalizer step).
+
+    :param expr_str: Python expression string.
+    :param origin: Source origin label.
+    :returns: ``(ExpressionNode, diagnostics)``.
+    """
+    diagnostics: List[ExecutableDiagnostic] = []
+    if not expr_str or not expr_str.strip():
+        diag = ExecutableDiagnostic(
+            code="empty-expression",
+            outcome="normalize",
+            tier="restricted",
+            source_origin=origin,
+            message="Empty expression string",
+        )
+        diagnostics.append(diag)
+        return UnsupportedExpr(source=expr_str, diagnostic=diag), diagnostics
+
+    try:
+        tree = ast.parse(expr_str, mode="eval")
+    except SyntaxError as exc:
+        diag = ExecutableDiagnostic(
+            code="parse-error",
+            outcome="reject",
+            tier="forbidden",
+            source_origin=origin,
+            message="AST parse error: {}".format(exc),
+        )
+        diagnostics.append(diag)
+        return UnsupportedExpr(source=expr_str, diagnostic=diag), diagnostics
+
+    ir_node = _ast_to_expr(tree.body, origin)
+    if isinstance(ir_node, UnsupportedExpr):
+        diagnostics.append(ir_node.diagnostic)
+    return ir_node, diagnostics
+
+
+# ---------------------------------------------------------------------------
+# DataSlotIR lowering
+# ---------------------------------------------------------------------------
+
+_NUMERIC_RE = re.compile(r"^\s*-?\d+(\.\d+)?\s*$")
+
+
+def _lower_data_slot(data: Any, ctx: _LoweringContext) -> DataSlotIR:
+    """Lower one ``<data>`` element to a DataSlotIR.
+
+    :param data: Pydantic ``Data`` / ``ScxmlDataType`` model instance.
+    :param ctx: Lowering context.
+    :returns: DataSlotIR.
+    """
+    slot_id = getattr(data, "id", None) or ""
+    expr_src = getattr(data, "expr", None)
+    initial: Optional[Value] = None
+
+    if expr_src is not None:
+        expr_str = str(expr_src).strip()
+        ir_node = ctx.lower_expr(expr_str, "data:{}".format(slot_id))
+        # Convert simple literal IR nodes to Value tags
+        initial = _expr_to_value(ir_node)
+    return DataSlotIR(id=slot_id, initial_value=initial, expr_source=expr_src)
+
+
+def _expr_to_value(node: ExpressionNode) -> Optional[Value]:
+    """Convert a simple ExpressionNode literal to a tagged Value, if possible.
+
+    Used for datamodel initialization where the value is a compile-time
+    constant.  Non-constant nodes are left as ``None`` (value unknown at
+    lower time).
+
+    :param node: ExpressionNode to convert.
+    :returns: Tagged Value or ``None``.
+    """
+    if isinstance(node, NumericLiteral):
+        return NumberValue(v=node.num)
+    if isinstance(node, StringLiteral):
+        return StrValue(v=node.s)
+    if isinstance(node, BoolLiteral):
+        return BoolValue(v=node.b)
+    if isinstance(node, UndefinedValue):
+        return UndefinedValue()
+    if isinstance(node, ArrayLiteral):
+        items = [_expr_to_value(e) for e in node.items]
+        return ArrayValue(items=[v for v in items if v is not None])
+    if isinstance(node, MapLiteral):
+        entries = []
+        for k, v in node.entries:
+            kv = _expr_to_value(k)
+            vv = _expr_to_value(v)
+            if isinstance(kv, StrValue):
+                entries.append((kv.v, vv))
+        return MapValue(entries=entries)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Executable-content (action block) lowering
+# ---------------------------------------------------------------------------
+
+_MAX_FOREACH_DEPTH = 4  # D-M1P6-4
+_MAX_INVOKE_DEPTH = 2   # D-M1P6-5
+
+
+def _lower_send(send: Any, ctx: _LoweringContext, origin: str) -> SendNode:
+    """Lower a ``<send>`` element to a SendNode.
+
+    Handles both static (``event``, ``target``, ``delay``) and dynamic
+    (``eventexpr``, ``targetexpr``, ``delayexpr``) attributes per D-M1P6-6.
+
+    :param send: Pydantic Send model instance.
+    :param ctx: Lowering context.
+    :param origin: Source origin label.
+    :returns: SendNode.
+    """
+    event = getattr(send, "event", None)
+    target = getattr(send, "target", None)
+    delay = getattr(send, "delay", None)
+    send_id = getattr(send, "id", None)
+
+    eventexpr_ir: Optional[ExpressionNode] = None
+    targetexpr_ir: Optional[ExpressionNode] = None
+    delayexpr_ir: Optional[ExpressionNode] = None
+    content_expr_ir: Optional[ExpressionNode] = None
+
+    raw_eventexpr = getattr(send, "eventexpr", None)
+    raw_targetexpr = getattr(send, "targetexpr", None)
+    raw_delayexpr = getattr(send, "delayexpr", None)
+
+    if raw_eventexpr:
+        eventexpr_ir = ctx.lower_expr(str(raw_eventexpr), origin + ":eventexpr")
+    if raw_targetexpr:
+        targetexpr_ir = ctx.lower_expr(str(raw_targetexpr), origin + ":targetexpr")
+    if raw_delayexpr:
+        delayexpr_ir = ctx.lower_expr(str(raw_delayexpr), origin + ":delayexpr")
+
+    # <content expr=...>
+    for content in getattr(send, "content", []) or []:
+        expr_attr = getattr(content, "expr", None)
+        if expr_attr:
+            content_expr_ir = ctx.lower_expr(str(expr_attr), origin + ":content_expr")
+            break
+
+    # <param> elements
+    params: List[tuple] = []
+    for param in getattr(send, "param", []) or []:
+        pname = getattr(param, "name", None)
+        pexpr = getattr(param, "expr", None)
+        if pname and pexpr is not None:
+            param_ir = ctx.lower_expr(str(pexpr), origin + ":param:{}".format(pname))
+            params.append((pname, param_ir))
+
+    return SendNode(
+        event=event,
+        eventexpr=eventexpr_ir,
+        target=target,
+        targetexpr=targetexpr_ir,
+        delay=delay,
+        delayexpr=delayexpr_ir,
+        send_id=send_id,
+        content_expr=content_expr_ir,
+        params=params,
+        origin=OriginRef(type="send", state=origin),
+    )
+
+
+def _lower_foreach(
+    fe: Any, ctx: _LoweringContext, origin: str, depth: int = 1
+) -> ForeachNode:
+    """Lower a ``<foreach>`` element to a ForeachNode (D-M1P6-4).
+
+    :param fe: Pydantic Foreach model instance.
+    :param ctx: Lowering context.
+    :param origin: Source origin label.
+    :param depth: Current foreach nesting depth.
+    :returns: ForeachNode.
+    """
+    if depth > _MAX_FOREACH_DEPTH:
+        diag = ExecutableDiagnostic(
+            code="foreach-depth-exceeded",
+            outcome="reject",
+            tier="forbidden",
+            source_origin=origin,
+            message="foreach nesting depth {} exceeds maximum {} (D-M1P6-4)".format(
+                depth, _MAX_FOREACH_DEPTH
+            ),
+        )
+        ctx.push_diag(diag)
+
+    array_str = getattr(fe, "array", "[]")
+    array_ir = ctx.lower_expr(str(array_str), origin + ":foreach.array")
+    item = getattr(fe, "item", "_item")
+    index = getattr(fe, "index", None)
+    body = _lower_action_block(fe, ctx, origin + ":foreach", foreach_depth=depth)
+
+    return ForeachNode(
+        array_expr=array_ir,
+        item=item,
+        index=index,
+        body=body,
+        depth=depth,
+        origin=OriginRef(type="foreach", state=origin),
+    )
+
+
+def _lower_if(block: Any, ctx: _LoweringContext, origin: str) -> IfNode:
+    """Lower an ``<if>`` block to an IfNode.
+
+    :param block: Pydantic If model instance.
+    :param ctx: Lowering context.
+    :param origin: Source origin label.
+    :returns: IfNode.
+    """
+    branches: List[IfBranch] = []
+
+    # Primary if branch
+    cond_str = getattr(block, "cond", None)
+    guard_ir: Optional[ExpressionNode] = None
+    if cond_str:
+        guard_ir = ctx.lower_expr(str(cond_str), origin + ":if.cond")
+
+    # Reconstruct the branch body by looking at the sub-actions
+    # We gather the initial if body items from the transition / block's
+    # own action children, then switch on elseif/else tags.
+    # Use the same approach as the engine: collect action children in XML order.
+    primary_body = _lower_action_block(block, ctx, origin + ":if")
+
+    # Check for elseif
+    elseif = getattr(block, "elseif", None)
+    else_value = getattr(block, "else_value", None)
+
+    if elseif is not None or else_value is not None:
+        # The primary body items came from the block until the first elseif/else marker.
+        # For simplicity (and parity with the engine's _split_if_branches), treat
+        # all sub-action items from the block itself as the primary branch body.
+        branches.append(IfBranch(guard=guard_ir, body=primary_body))
+        # Add elseif branch
+        if elseif is not None:
+            elseif_cond = getattr(elseif, "cond", None)
+            elseif_guard: Optional[ExpressionNode] = None
+            if elseif_cond:
+                elseif_guard = ctx.lower_expr(
+                    str(elseif_cond), origin + ":elseif.cond"
+                )
+            branches.append(IfBranch(guard=elseif_guard, body=[]))
+        # Add else branch
+        if else_value is not None:
+            branches.append(IfBranch(guard=None, body=[]))
+    else:
+        branches.append(IfBranch(guard=guard_ir, body=primary_body))
+
+    return IfNode(branches=branches, origin=OriginRef(type="if", state=origin))
+
+
+def _lower_script(
+    script: Any, ctx: _LoweringContext, origin: str, state: str, idx: int
+) -> CapabilityCallNode:
+    """Lower a ``<script>`` element to a CapabilityCallNode (M1P3).
+
+    :param script: Pydantic Script model instance.
+    :param ctx: Lowering context.
+    :param origin: Source origin label.
+    :param state: Owning state id for name synthesis.
+    :param idx: Index within the parent block.
+    :returns: CapabilityCallNode.
+    """
+    script_name = getattr(script, "name", None)
+    block_type = origin.split(":")[-1] if ":" in origin else origin
+    name = ctx.synth_cap_name(
+        script_name=script_name, block_type=block_type, state=state, idx=idx
+    )
+    origin_ref = OriginRef(type="script", state=state, idx=idx)
+    return CapabilityCallNode(
+        name=name,
+        origin=origin_ref,
+        success_event="{}.success".format(name),
+        error_event="{}.error".format(name),
+    )
+
+
+def _lower_action_block(
+    container: Any,
+    ctx: _LoweringContext,
+    origin: str,
+    foreach_depth: int = 0,
+) -> List[ActionNode]:
+    """Lower all executable-content children of *container* in document order.
+
+    Iterates over the action-type lists on the pydantic model; ordering
+    follows the same precedence as the engine's ``_build_action_sequence``.
+
+    :param container: Pydantic model with action list attributes.
+    :param ctx: Lowering context.
+    :param origin: Source origin label.
+    :param foreach_depth: Current foreach nesting depth (for depth checks).
+    :returns: Ordered list of ActionNode.
+    """
+    actions: List[ActionNode] = []
+
+    # Walk known action list attributes in document-declared field order.
+    # raise_value, if_value, foreach, assign, log, script, send, cancel
+    # For onentry/onexit types the attribute bag is the same.
+
+    state_id = _extract_state_from_origin(origin)
+    script_counter = [0]  # mutable to allow closure increment
+
+    def _push_assign(item: Any) -> None:
+        loc = getattr(item, "location", None) or ""
+        expr_src = getattr(item, "expr", None) or ""
+        op_enum = getattr(item, "type_value", None)
+        op = "set"
+        if op_enum is not None:
+            op_str = str(op_enum).lower()
+            if "add" in op_str:
+                op = "add"
+            elif "sub" in op_str:
+                op = "sub"
+            elif "mul" in op_str:
+                op = "mul"
+            elif "div" in op_str:
+                op = "div"
+        expr_ir = ctx.lower_expr(str(expr_src), origin + ":assign")
+        actions.append(
+            AssignNode(
+                loc=loc,
+                expr=expr_ir,
+                op=op,
+                origin=OriginRef(type="assign", state=state_id),
+            )
+        )
+
+    def _push_log(item: Any) -> None:
+        expr_src = getattr(item, "expr", None) or ""
+        label = getattr(item, "label", None)
+        expr_ir = ctx.lower_expr(str(expr_src), origin + ":log")
+        actions.append(
+            LogNode(
+                expr=expr_ir,
+                label=label,
+                origin=OriginRef(type="log", state=state_id),
+            )
+        )
+
+    def _push_raise(item: Any) -> None:
+        event_name = getattr(item, "event", None) or ""
+        actions.append(
+            RaiseNode(
+                event=event_name,
+                origin=OriginRef(type="raise", state=state_id),
+            )
+        )
+
+    def _push_send(item: Any) -> None:
+        actions.append(_lower_send(item, ctx, origin))
+
+    def _push_cancel(item: Any) -> None:
+        sendid = getattr(item, "sendid", None)
+        actions.append(
+            CancelNode(sendid=sendid, origin=OriginRef(type="cancel", state=state_id))
+        )
+
+    def _push_if(item: Any) -> None:
+        actions.append(_lower_if(item, ctx, origin))
+
+    def _push_foreach(item: Any) -> None:
+        depth = foreach_depth + 1
+        actions.append(_lower_foreach(item, ctx, origin, depth=depth))
+
+    def _push_script(item: Any) -> None:
+        idx = script_counter[0]
+        script_counter[0] += 1
+        actions.append(_lower_script(item, ctx, origin, state_id, idx))
+
+    # Map attribute names on the pydantic model to action kinds
+    # We visit in a fixed order but the important thing is we visit all items.
+    _handlers: List[tuple] = [
+        ("raise_value", _push_raise),
+        ("assign", _push_assign),
+        ("log", _push_log),
+        ("send", _push_send),
+        ("cancel", _push_cancel),
+        ("if_value", _push_if),
+        ("foreach", _push_foreach),
+        ("script", _push_script),
+    ]
+
+    # Collect all items from each list, then sort by document order.
+    # We attempt to use XML round-trip order when available; otherwise
+    # fall back to the per-attribute order above.
+    ordered = _collect_actions_ordered(container, _handlers, ctx, origin)
+    return ordered
+
+
+def _collect_actions_ordered(
+    container: Any,
+    handlers: List[tuple],
+    ctx: _LoweringContext,
+    origin: str,
+) -> List[ActionNode]:
+    """Collect actions from *container* using document-order XML if possible.
+
+    Falls back to the handler order from *handlers* if XML round-trip is
+    unavailable (e.g. in deeply nested inline invoke content).
+
+    :param container: Pydantic model with action list attributes.
+    :param handlers: Ordered list of ``(attr_name, handler)`` pairs.
+    :param ctx: Lowering context.
+    :param origin: Source origin label.
+    :returns: Ordered list of ActionNode.
+    """
+    from xml.etree import ElementTree as ET
+    from .SCXMLDocumentHandler import SCXMLDocumentHandler
+    from . import dataclasses as dataclasses_module
+
+    _serializer = SCXMLDocumentHandler(
+        pretty=False,
+        omit_empty=False,
+        fail_on_unknown_properties=False,
+    )
+
+    def _local_name(tag: str) -> str:
+        return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+    # Attempt XML round-trip to get true document order
+    xml_order: Optional[List[str]] = None
+    try:
+        if hasattr(container, "__dataclass_fields__"):
+            dc_obj = container
+        elif hasattr(container, "model_dump"):
+            cls = getattr(dataclasses_module, type(container).__name__)
+            data = container.model_dump(mode="python")
+            dc_obj = _serializer._to_dataclass(cls, data)
+        else:
+            dc_obj = None
+
+        if dc_obj is not None:
+            xml_str = _serializer.to_string(dc_obj)
+            root = ET.fromstring(xml_str)
+            xml_order = [_local_name(child.tag) for child in list(root)]
+    except Exception:
+        xml_order = None
+
+    state_id = _extract_state_from_origin(origin)
+    script_counter = [0]
+    all_actions: List[ActionNode] = []
+
+    if xml_order is not None:
+        # Build per-type item queues
+        queues: Dict[str, List[Any]] = {}
+        for attr_name, _ in handlers:
+            items = list(getattr(container, attr_name, []) or [])
+            queues[attr_name] = items
+        cursors: Dict[str, int] = {k: 0 for k in queues}
+
+        _tag_to_attr = {
+            "raise": "raise_value",
+            "assign": "assign",
+            "log": "log",
+            "send": "send",
+            "cancel": "cancel",
+            "if": "if_value",
+            "foreach": "foreach",
+            "script": "script",
+        }
+
+        for tag in xml_order:
+            attr_name = _tag_to_attr.get(tag)
+            if attr_name is None:
+                continue
+            q = queues.get(attr_name, [])
+            idx = cursors.get(attr_name, 0)
+            if idx >= len(q):
+                continue
+            item = q[idx]
+            cursors[attr_name] = idx + 1
+
+            if attr_name == "raise_value":
+                event_name = getattr(item, "event", None) or ""
+                all_actions.append(
+                    RaiseNode(event=event_name, origin=OriginRef(type="raise", state=state_id))
+                )
+            elif attr_name == "assign":
+                loc = getattr(item, "location", None) or ""
+                expr_src = getattr(item, "expr", None) or ""
+                op_enum = getattr(item, "type_value", None)
+                op = "set"
+                if op_enum is not None:
+                    op_str = str(op_enum).lower()
+                    if "add" in op_str:
+                        op = "add"
+                    elif "sub" in op_str:
+                        op = "sub"
+                    elif "mul" in op_str:
+                        op = "mul"
+                    elif "div" in op_str:
+                        op = "div"
+                expr_ir = ctx.lower_expr(str(expr_src), origin + ":assign")
+                all_actions.append(
+                    AssignNode(loc=loc, expr=expr_ir, op=op, origin=OriginRef(type="assign", state=state_id))
+                )
+            elif attr_name == "log":
+                expr_src = getattr(item, "expr", None) or ""
+                label = getattr(item, "label", None)
+                expr_ir = ctx.lower_expr(str(expr_src), origin + ":log")
+                all_actions.append(
+                    LogNode(expr=expr_ir, label=label, origin=OriginRef(type="log", state=state_id))
+                )
+            elif attr_name == "send":
+                all_actions.append(_lower_send(item, ctx, origin))
+            elif attr_name == "cancel":
+                sendid = getattr(item, "sendid", None)
+                all_actions.append(
+                    CancelNode(sendid=sendid, origin=OriginRef(type="cancel", state=state_id))
+                )
+            elif attr_name == "if_value":
+                all_actions.append(_lower_if(item, ctx, origin))
+            elif attr_name == "foreach":
+                depth = 1
+                all_actions.append(_lower_foreach(item, ctx, origin, depth=depth))
+            elif attr_name == "script":
+                sc_idx = script_counter[0]
+                script_counter[0] += 1
+                all_actions.append(_lower_script(item, ctx, origin, state_id, sc_idx))
+
+        return all_actions
+
+    # Fallback: use handler order
+    for attr_name, handler_fn in handlers:
+        items = list(getattr(container, attr_name, []) or [])
+        for item in items:
+            if attr_name == "script":
+                sc_idx = script_counter[0]
+                script_counter[0] += 1
+                all_actions.append(_lower_script(item, ctx, origin, state_id, sc_idx))
+            else:
+                # Call the appropriate inline logic
+                if attr_name == "raise_value":
+                    event_name = getattr(item, "event", None) or ""
+                    all_actions.append(
+                        RaiseNode(event=event_name, origin=OriginRef(type="raise", state=state_id))
+                    )
+                elif attr_name == "assign":
+                    loc = getattr(item, "location", None) or ""
+                    expr_src = getattr(item, "expr", None) or ""
+                    expr_ir = ctx.lower_expr(str(expr_src), origin + ":assign")
+                    all_actions.append(
+                        AssignNode(loc=loc, expr=expr_ir, op="set", origin=OriginRef(type="assign", state=state_id))
+                    )
+                elif attr_name == "log":
+                    expr_src = getattr(item, "expr", None) or ""
+                    label = getattr(item, "label", None)
+                    expr_ir = ctx.lower_expr(str(expr_src), origin + ":log")
+                    all_actions.append(
+                        LogNode(expr=expr_ir, label=label, origin=OriginRef(type="log", state=state_id))
+                    )
+                elif attr_name == "send":
+                    all_actions.append(_lower_send(item, ctx, origin))
+                elif attr_name == "cancel":
+                    sendid = getattr(item, "sendid", None)
+                    all_actions.append(
+                        CancelNode(sendid=sendid, origin=OriginRef(type="cancel", state=state_id))
+                    )
+                elif attr_name == "if_value":
+                    all_actions.append(_lower_if(item, ctx, origin))
+                elif attr_name == "foreach":
+                    all_actions.append(_lower_foreach(item, ctx, origin, depth=1))
+
+    return all_actions
+
+
+def _extract_state_from_origin(origin: str) -> str:
+    """Extract the state id from an origin label string.
+
+    :param origin: Origin label like ``"state:Thinking:onentry"``.
+    :returns: The first segment before a colon, or the whole string.
+    """
+    return origin.split(":")[0] if ":" in origin else origin
+
+
+# ---------------------------------------------------------------------------
+# Invoke lowering
+# ---------------------------------------------------------------------------
+
+
+def _lower_invoke(
+    inv: Any, ctx: _LoweringContext, parent_state: str
+) -> InvokeIR:
+    """Lower an ``<invoke>`` element to an InvokeIR.
+
+    Inline ``<content><scxml>`` child machines are lowered recursively
+    per D-M1P6-5, bounded to depth 2.
+
+    :param inv: Pydantic Invoke model instance.
+    :param ctx: Lowering context.
+    :param parent_state: Id of the state containing this invoke.
+    :returns: InvokeIR.
+    """
+    invoke_id = getattr(inv, "id", None)
+    type_value = getattr(inv, "type_value", None) or "scxml"
+    src = getattr(inv, "src", None)
+    af = getattr(inv, "autoforward", None)
+    autoforward = str(af).lower() in {"true", "booleandata.true"} if af is not None else False
+
+    params: List[tuple] = []
+    for param in getattr(inv, "param", []) or []:
+        pname = getattr(param, "name", None)
+        pexpr = getattr(param, "expr", None)
+        if pname and pexpr is not None:
+            param_ir = ctx.lower_expr(str(pexpr), "invoke:{}:param:{}".format(parent_state, pname))
+            params.append((pname, param_ir))
+
+    child_machine: Optional[MachineIR] = None
+    content_items = getattr(inv, "content", []) or []
+    for content in content_items:
+        # Look for inline <scxml> inside <content>
+        inner_list = getattr(content, "content", []) or []
+        for inner in inner_list:
+            from .pydantic import Scxml as _PydScxml
+            if isinstance(inner, _PydScxml):
+                if ctx.invoke_depth >= _MAX_INVOKE_DEPTH:
+                    diag = ExecutableDiagnostic(
+                        code="invoke-depth-exceeded",
+                        outcome="reject",
+                        tier="forbidden",
+                        source_origin=parent_state,
+                        message="inline invoke nesting depth exceeds maximum {} (D-M1P6-5)".format(
+                            _MAX_INVOKE_DEPTH
+                        ),
+                    )
+                    ctx.push_diag(diag)
+                else:
+                    child_ctx = _LoweringContext(
+                        ecmascript_mode=_is_ecmascript(inner),
+                        invoke_depth=ctx.invoke_depth + 1,
+                    )
+                    child_machine = _lower_scxml(inner, child_ctx)
+                    ctx.diagnostics.extend(child_ctx.diagnostics)
+                break
+        if child_machine is not None:
+            break
+
+    if src is not None and child_machine is None:
+        # External src reference — not admitted by M1P6
+        diag = ExecutableDiagnostic(
+            code="unsupported-invoke-src",
+            outcome="normalize",
+            tier="restricted",
+            source_origin=parent_state,
+            message="<invoke src={}> is not admitted by M1P6; only inline <content> is supported".format(
+                src
+            ),
+        )
+        ctx.push_diag(diag)
+
+    return InvokeIR(
+        invoke_id=invoke_id,
+        type_value=type_value,
+        src=src,
+        child_machine=child_machine,
+        params=params,
+        autoforward=autoforward,
+        depth=ctx.invoke_depth + 1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transition lowering
+# ---------------------------------------------------------------------------
+
+
+def _lower_transition(trans: Any, ctx: _LoweringContext, state_id: str) -> TransitionIR:
+    """Lower one ``<transition>`` element to a TransitionIR.
+
+    :param trans: Pydantic Transition model instance.
+    :param ctx: Lowering context.
+    :param state_id: Owning state id.
+    :returns: TransitionIR.
+    """
+    event = getattr(trans, "event", None)
+    targets = list(getattr(trans, "target", []) or [])
+    cond = getattr(trans, "cond", None)
+
+    guard_ir: Optional[ExpressionNode] = None
+    diags: List[ExecutableDiagnostic] = []
+    if cond:
+        origin = "{}:trans".format(state_id)
+        guard_ir = ctx.lower_expr(str(cond), origin)
+        # Collect diagnostics from the lowered guard
+        if isinstance(guard_ir, UnsupportedExpr):
+            diags.append(guard_ir.diagnostic)
+
+    origin_ref = OriginRef(
+        type="transition",
+        state=state_id,
+        src=state_id,
+        dst=targets,
+    )
+    actions = _lower_action_block(trans, ctx, "{}:trans".format(state_id))
+
+    return TransitionIR(
+        event=event,
+        targets=targets,
+        guard=guard_ir,
+        actions=actions,
+        origin=origin_ref,
+        diagnostics=diags,
+    )
+
+
+# ---------------------------------------------------------------------------
+# State-tree lowering helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_ecmascript(doc: Any) -> bool:
+    """Return True when *doc* declares datamodel="ecmascript".
+
+    :param doc: Pydantic Scxml model.
+    :returns: True if ECMAScript datamodel.
+    """
+    dm = getattr(doc, "datamodel_attribute", None) or getattr(doc, "datamodel", None)
+    return str(dm).lower() == "ecmascript"
+
+
+def _lower_datamodel(node: Any, ctx: _LoweringContext) -> List[DataSlotIR]:
+    """Lower all ``<datamodel>`` blocks on *node*.
+
+    :param node: Pydantic SCXML node with a ``datamodel`` attribute.
+    :param ctx: Lowering context.
+    :returns: List of DataSlotIR.
+    """
+    slots: List[DataSlotIR] = []
+    for dm in getattr(node, "datamodel", []) or []:
+        for data in getattr(dm, "data", []) or []:
+            slots.append(_lower_data_slot(data, ctx))
+    return slots
+
+
+def _lower_onentry(node: Any, ctx: _LoweringContext, state_id: str) -> List[ActionNode]:
+    """Lower onentry blocks for *node*.
+
+    :param node: Pydantic SCXML state node.
+    :param ctx: Lowering context.
+    :param state_id: Owning state id for diagnostics.
+    :returns: Ordered action list.
+    """
+    actions: List[ActionNode] = []
+    for entry in getattr(node, "onentry", []) or []:
+        actions.extend(_lower_action_block(entry, ctx, "{}:onentry".format(state_id)))
+    return actions
+
+
+def _lower_onexit(node: Any, ctx: _LoweringContext, state_id: str) -> List[ActionNode]:
+    """Lower onexit blocks for *node*.
+
+    :param node: Pydantic SCXML state node.
+    :param ctx: Lowering context.
+    :param state_id: Owning state id for diagnostics.
+    :returns: Ordered action list.
+    """
+    actions: List[ActionNode] = []
+    for onexit in getattr(node, "onexit", []) or []:
+        actions.extend(_lower_action_block(onexit, ctx, "{}:onexit".format(state_id)))
+    return actions
+
+
+def _lower_state(node: Any, ctx: _LoweringContext, parent_id: str) -> StateIR:
+    """Lower a ``<state>`` element recursively.
+
+    :param node: Pydantic State model.
+    :param ctx: Lowering context.
+    :param parent_id: Parent state id (for diagnostics).
+    :returns: StateIR.
+    """
+    from .pydantic import History as _PydHistory, ScxmlFinalType as _PydFinal
+
+    state_id = getattr(node, "id", None) or "anon_{}".format(id(node))
+    initial_attr = getattr(node, "initial_attribute", None)
+    if not initial_attr:
+        initial_nodes = getattr(node, "initial", []) or []
+        if initial_nodes:
+            first = initial_nodes[0]
+            tgt = getattr(getattr(first, "transition", None), "target", None)
+            initial_attr = list(tgt)[0] if tgt else None
+
+    datamodel = _lower_datamodel(node, ctx)
+    onentry = _lower_onentry(node, ctx, state_id)
+    onexit = _lower_onexit(node, ctx, state_id)
+    transitions = [
+        _lower_transition(t, ctx, state_id)
+        for t in getattr(node, "transition", []) or []
+    ]
+
+    invokes: List[InvokeIR] = []
+    for inv in getattr(node, "invoke", []) or []:
+        invokes.append(_lower_invoke(inv, ctx, state_id))
+
+    children: List[AnyStateIR] = []
+    for child in getattr(node, "state", []) or []:
+        children.append(_lower_state(child, ctx, state_id))
+    for child in getattr(node, "parallel", []) or []:
+        children.append(_lower_parallel(child, ctx, state_id))
+    for child in getattr(node, "final", []) or []:
+        child_id = getattr(child, "id", None) or "final_{}".format(id(child))
+        children.append(FinalIR(id=child_id))
+    for child in getattr(node, "history", []) or []:
+        child_id = getattr(child, "id", None) or "hist_{}".format(id(child))
+        hist_type = getattr(child, "type_value", "shallow") or "shallow"
+        children.append(HistoryIR(id=child_id, type=str(hist_type)))
+
+    return StateIR(
+        id=state_id,
+        initial=str(initial_attr) if initial_attr else None,
+        datamodel=datamodel,
+        onentry=onentry,
+        onexit=onexit,
+        transitions=transitions,
+        children=children,
+        invokes=invokes,
+    )
+
+
+def _lower_parallel(node: Any, ctx: _LoweringContext, parent_id: str) -> ParallelIR:
+    """Lower a ``<parallel>`` element recursively.
+
+    :param node: Pydantic ScxmlParallelType model.
+    :param ctx: Lowering context.
+    :param parent_id: Parent id (for diagnostics).
+    :returns: ParallelIR.
+    """
+    parallel_id = getattr(node, "id", None) or "parallel_{}".format(id(node))
+    datamodel = _lower_datamodel(node, ctx)
+    onentry = _lower_onentry(node, ctx, parallel_id)
+    onexit = _lower_onexit(node, ctx, parallel_id)
+    transitions = [
+        _lower_transition(t, ctx, parallel_id)
+        for t in getattr(node, "transition", []) or []
+    ]
+
+    invokes: List[InvokeIR] = []
+    for inv in getattr(node, "invoke", []) or []:
+        invokes.append(_lower_invoke(inv, ctx, parallel_id))
+
+    children: List[AnyStateIR] = []
+    for child in getattr(node, "state", []) or []:
+        children.append(_lower_state(child, ctx, parallel_id))
+    for child in getattr(node, "parallel", []) or []:
+        children.append(_lower_parallel(child, ctx, parallel_id))
+    for child in getattr(node, "final", []) or []:
+        child_id = getattr(child, "id", None) or "final_{}".format(id(child))
+        children.append(FinalIR(id=child_id))
+    for child in getattr(node, "history", []) or []:
+        child_id = getattr(child, "id", None) or "hist_{}".format(id(child))
+        hist_type = getattr(child, "type_value", "shallow") or "shallow"
+        children.append(HistoryIR(id=child_id, type=str(hist_type)))
+
+    return ParallelIR(
+        id=parallel_id,
+        datamodel=datamodel,
+        onentry=onentry,
+        onexit=onexit,
+        transitions=transitions,
+        children=children,
+        invokes=invokes,
+    )
+
+
+def _lower_scxml(doc: Any, ctx: _LoweringContext) -> MachineIR:
+    """Lower the root ``<scxml>`` element to a MachineIR.
+
+    This is the recursive core used both for the top-level document and for
+    inline ``<content><scxml>`` child machines (D-M1P6-5).
+
+    :param doc: Pydantic Scxml model.
+    :param ctx: Lowering context (owns the diagnostic list).
+    :returns: MachineIR.
+    """
+    name = getattr(doc, "name", None)
+    datamodel_attr = getattr(doc, "datamodel_attribute", None) or "null"
+    initial_attr = getattr(doc, "initial", None) or []
+
+    datamodel = _lower_datamodel(doc, ctx)
+
+    children: List[AnyStateIR] = []
+    for child in getattr(doc, "state", []) or []:
+        children.append(_lower_state(child, ctx, "__root__"))
+    for child in getattr(doc, "parallel", []) or []:
+        children.append(_lower_parallel(child, ctx, "__root__"))
+    for child in getattr(doc, "final", []) or []:
+        child_id = getattr(child, "id", None) or "final_{}".format(id(child))
+        children.append(FinalIR(id=child_id))
+
+    return MachineIR(
+        name=name,
+        datamodel_attr=datamodel_attr,
+        initial=list(initial_attr),
+        datamodel=datamodel,
+        children=children,
+        diagnostics=ctx.diagnostics,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def lower_document(doc: Any) -> tuple:
+    """Lower a parsed SCJSON/SCXML Pydantic document to a MachineIR.
+
+    This is the primary API of the M1 Executable IR layer.  The returned
+    MachineIR carries all diagnostics collected during lowering; every
+    un-lowerable construct produces a diagnostic rather than being silently
+    dropped (D-M1P6-8).
+
+    :param doc: A ``Scxml`` Pydantic model instance (from ``pydantic.generated``).
+        Also accepts any model with the SCXML root interface (used for inline
+        child machines in tests).
+    :returns: ``(MachineIR, diagnostics)`` where ``diagnostics`` is the flat
+        list of all ``ExecutableDiagnostic`` items collected.  The list is also
+        accessible as ``machine_ir.diagnostics``.
+    """
+    ecmascript = _is_ecmascript(doc)
+    ctx = _LoweringContext(ecmascript_mode=ecmascript, invoke_depth=0)
+    machine = _lower_scxml(doc, ctx)
+    return machine, ctx.diagnostics

--- a/py/scjson/exec_ir.py
+++ b/py/scjson/exec_ir.py
@@ -50,8 +50,15 @@ Deviations from M1-EXECUTABLE-IR spec (none; full compliance):
   - M1P2 seven ActionNode families are all implemented.
   - M1P6 ForeachNode, inline-invoke nested MachineIR, dynamic Send slots
     are implemented per D-M1P6-4, D-M1P6-5, D-M1P6-6.
-  - CapabilityCallNode: script elements map to CapabilityCallNode per M1P3;
-    name synthesis follows the frozen pattern.
+  - CapabilityCallNode: script elements whose bodies contain any unadmitted
+    ECMAScript form map to CapabilityCallNode per M0-D10; name synthesis
+    follows the frozen pattern.  Script elements whose bodies consist entirely
+    of admitted assign / if statements are lowered directly to AssignNode /
+    IfNode sequences per D-M1P6-2 (Fix 1).
+  - Inline invoke child-machine detection now recognizes both
+    scjson.pydantic.Scxml and scjson.dataclasses.Scxml (plus a duck-type
+    fallback) so that SCXMLDocumentHandler-parsed documents populate
+    InvokeIR.child_machine correctly (Fix 2).
   - Diagnostics are collected (never raised) per D-M1P6-8.
 """
 
@@ -1332,24 +1339,248 @@ def _lower_if(block: Any, ctx: _LoweringContext, origin: str) -> IfNode:
     return IfNode(branches=branches, origin=OriginRef(type="if", state=origin))
 
 
-def _lower_script(
-    script: Any, ctx: _LoweringContext, origin: str, state: str, idx: int
-) -> CapabilityCallNode:
-    """Lower a ``<script>`` element to a CapabilityCallNode (M1P3).
+def _lower_script_body(
+    body_text: str, ctx: _LoweringContext, origin: str, state: str, idx: int
+) -> Optional[List["ActionNode"]]:
+    """Attempt to lower a ``<script>`` body as a sequence of admitted statements.
 
-    :param script: Pydantic Script model instance.
+    D-M1P6-2 admits inside ``<script>``:
+    - Assignment to a datamodel location (incl. computed-member ``t[k] = v``).
+    - ``if (cond) { ... }`` whose body is itself admitted (recursively).
+
+    If every top-level statement in *body_text* is admitted, returns the
+    equivalent ``ActionNode`` sequence (``AssignNode`` and/or ``IfNode`` items
+    in document order).  If ANY statement is unadmitted, returns ``None``
+    (callers must fall through to the ``CapabilityCallNode`` path — do NOT
+    partially-lower a mixed block per D-M1P6-2).
+
+    :param body_text: Raw JS ``<script>`` body text.
+    :param ctx: Lowering context (diagnostics collected here).
+    :param origin: Source origin label for diagnostics.
+    :param state: Owning state id for ``OriginRef``.
+    :param idx: Block index within the parent executable content block.
+    :returns: List of ``ActionNode`` when the body is fully admitted, else
+        ``None``.
+    """
+    from .ecmascript_normalizer import (
+        ECMAScriptNormalizationError,
+        normalize_script as _normalize_script,
+    )
+
+    # Step 1: Normalize the JS body to Python statement text.
+    try:
+        py_text = _normalize_script(body_text)
+    except ECMAScriptNormalizationError:
+        return None
+
+    # Step 2: Parse as an exec-mode module.
+    try:
+        module = ast.parse(py_text, mode="exec")
+    except SyntaxError:
+        return None
+
+    # Step 3: Try to lower each top-level statement to an ActionNode.
+    # If any statement is not admitted, abort the whole sequence.
+    result: List[ActionNode] = []
+    origin_ref = OriginRef(type="script", state=state, idx=idx)
+
+    def _lower_stmt(stmt: ast.stmt) -> Optional[ActionNode]:
+        """Lower one admitted statement to an ActionNode, or return None."""
+        if isinstance(stmt, ast.Assign):
+            return _lower_ast_assign(stmt, ctx, origin, state)
+        if isinstance(stmt, ast.If):
+            return _lower_ast_if(stmt, ctx, origin, state, origin_ref)
+        # Any other statement type is not admitted.
+        return None
+
+    for stmt in module.body:
+        node = _lower_stmt(stmt)
+        if node is None:
+            return None  # Entire block is unadmitted; caller emits CapabilityCallNode.
+        result.append(node)
+
+    return result
+
+
+def _lower_ast_assign(
+    stmt: ast.Assign, ctx: _LoweringContext, origin: str, state: str
+) -> Optional["AssignNode"]:
+    """Lower a Python ``ast.Assign`` node from a script body to an AssignNode.
+
+    Supports simple name assignments (``x = expr``) and computed-member
+    assignments (``t[k] = expr``, ``obj.attr = expr``).
+
+    :param stmt: Python AST Assign statement.
+    :param ctx: Lowering context.
+    :param origin: Source origin label for sub-expression diagnostics.
+    :param state: Owning state id for the OriginRef.
+    :returns: AssignNode, or ``None`` when the target form is not admitted.
+    """
+    if len(stmt.targets) != 1:
+        return None  # Multiple assignment targets are not admitted.
+    target = stmt.targets[0]
+
+    # Compute the location string for AssignNode.loc.
+    if isinstance(target, ast.Name):
+        loc = target.id
+    elif isinstance(target, ast.Subscript):
+        # Represent as "obj[key]" using unparse so the emitter can reconstruct it.
+        loc = ast.unparse(target) if hasattr(ast, "unparse") else repr(target)
+    elif isinstance(target, ast.Attribute):
+        loc = ast.unparse(target) if hasattr(ast, "unparse") else repr(target)
+    else:
+        return None  # Complex destructuring is not admitted.
+
+    # Lower the right-hand side expression.
+    rhs_source = ast.unparse(stmt.value) if hasattr(ast, "unparse") else repr(stmt.value)
+    rhs_ir = _ast_to_expr(stmt.value, origin + ":script:assign")
+
+    return AssignNode(
+        loc=loc,
+        expr=rhs_ir,
+        op="set",
+        origin=OriginRef(type="assign", state=state),
+    )
+
+
+def _lower_ast_if(
+    stmt: ast.If,
+    ctx: _LoweringContext,
+    origin: str,
+    state: str,
+    parent_ref: "OriginRef",
+) -> Optional["IfNode"]:
+    """Lower a Python ``ast.If`` node from a script body to an IfNode.
+
+    The condition and all body statements must be admitted (D-M1P6-2).
+    Else branches are supported when their body statements are also admitted.
+
+    :param stmt: Python AST If statement.
     :param ctx: Lowering context.
     :param origin: Source origin label.
-    :param state: Owning state id for name synthesis.
+    :param state: Owning state id.
+    :param parent_ref: OriginRef of the enclosing script block.
+    :returns: IfNode, or ``None`` when any sub-expression/statement is
+        unadmitted.
+    """
+    guard_ir = _ast_to_expr(stmt.test, origin + ":script:if.cond")
+    if isinstance(guard_ir, UnsupportedExpr):
+        return None
+
+    body_actions: List[ActionNode] = []
+    for s in stmt.body:
+        if isinstance(s, ast.Assign):
+            node = _lower_ast_assign(s, ctx, origin, state)
+        elif isinstance(s, ast.If):
+            node = _lower_ast_if(s, ctx, origin, state, parent_ref)
+        else:
+            return None  # Unadmitted body statement.
+        if node is None:
+            return None
+        body_actions.append(node)
+
+    branches = [IfBranch(guard=guard_ir, body=body_actions)]
+
+    # Lower orelse (else / elif) when present.
+    if stmt.orelse:
+        if len(stmt.orelse) == 1 and isinstance(stmt.orelse[0], ast.If):
+            # elif branch
+            elif_node = _lower_ast_if(stmt.orelse[0], ctx, origin, state, parent_ref)
+            if elif_node is None:
+                return None
+            branches.extend(elif_node.branches)
+        else:
+            # else branch
+            else_actions: List[ActionNode] = []
+            for s in stmt.orelse:
+                if isinstance(s, ast.Assign):
+                    node = _lower_ast_assign(s, ctx, origin, state)
+                elif isinstance(s, ast.If):
+                    node = _lower_ast_if(s, ctx, origin, state, parent_ref)
+                else:
+                    return None
+                if node is None:
+                    return None
+                else_actions.append(node)
+            branches.append(IfBranch(guard=None, body=else_actions))
+
+    return IfNode(
+        branches=branches,
+        origin=OriginRef(type="if", state=state),
+    )
+
+
+def _lower_script(
+    script: Any, ctx: _LoweringContext, origin: str, state: str, idx: int
+) -> Union[List["ActionNode"], "CapabilityCallNode"]:
+    """Lower a ``<script>`` element.
+
+    First attempts to parse the script body as a sequence of admitted
+    statements per D-M1P6-2 (assignments and ``if`` blocks).  If every
+    statement is admitted the function returns the resulting ``ActionNode``
+    list (an ``AssignNode`` / ``IfNode`` sequence in document order).
+
+    If any statement is not admitted — or when the body cannot be normalized
+    at all — falls back to the M0-D10 ``CapabilityCallNode`` path with the
+    appropriate diagnostic (D-M1P6-8).  A mixed block is never partially
+    lowered.
+
+    :param script: Pydantic/dataclass Script model instance.
+    :param ctx: Lowering context (diagnostics appended here on fallback).
+    :param origin: Source origin label.
+    :param state: Owning state id for name synthesis and ``OriginRef``.
     :param idx: Index within the parent block.
-    :returns: CapabilityCallNode.
+    :returns: Either a list of ``ActionNode`` (all-admitted path) or a single
+        ``CapabilityCallNode`` (fallback path).
     """
     script_name = getattr(script, "name", None)
     block_type = origin.split(":")[-1] if ":" in origin else origin
+
+    # Gather the raw body text.  Script body storage varies by representation:
+    # - pydantic model: ``value`` (str) or ``content`` (str)
+    # - dataclasses model (from SCXMLDocumentHandler): ``content`` is a list
+    #   of text segments (one element per text node in the SCXML).  Join them.
+    body_text: Optional[str] = None
+    for attr in ("value", "content", "_value"):
+        v = getattr(script, attr, None)
+        if v is None:
+            continue
+        if isinstance(v, str):
+            body_text = v.strip()
+            break
+        if isinstance(v, (list, tuple)):
+            # SCXMLDocumentHandler stores text content as a list of strings.
+            joined = "".join(str(s) for s in v).strip()
+            if joined:
+                body_text = joined
+                break
+
+    # If the machine is in ECMAScript mode and we have body text, attempt
+    # to lower as an admitted statement sequence (D-M1P6-2).
+    if ctx.ecmascript_mode and body_text:
+        admitted = _lower_script_body(body_text, ctx, origin, state, idx)
+        if admitted is not None:
+            # Fully admitted: return the sequence directly.
+            return admitted
+
+    # Fallback: emit a CapabilityCallNode (M0-D10 / D-M1P6-8).
     name = ctx.synth_cap_name(
         script_name=script_name, block_type=block_type, state=state, idx=idx
     )
     origin_ref = OriginRef(type="script", state=state, idx=idx)
+    if ctx.ecmascript_mode and body_text:
+        # The body was present but not admitted; emit a diagnostic.
+        diag = ExecutableDiagnostic(
+            code="unsupported-ecmascript",
+            outcome="capability-only",
+            tier="restricted",
+            source_origin=origin,
+            message=(
+                "script body contains unadmitted ECMAScript forms; "
+                "lowered to CapabilityCallNode '{}' (M0-D10 / D-M1P6-8)".format(name)
+            ),
+        )
+        ctx.push_diag(diag)
     return CapabilityCallNode(
         name=name,
         origin=origin_ref,
@@ -1449,7 +1680,11 @@ def _lower_action_block(
     def _push_script(item: Any) -> None:
         idx = script_counter[0]
         script_counter[0] += 1
-        actions.append(_lower_script(item, ctx, origin, state_id, idx))
+        result = _lower_script(item, ctx, origin, state_id, idx)
+        if isinstance(result, list):
+            actions.extend(result)
+        else:
+            actions.append(result)
 
     # Map attribute names on the pydantic model to action kinds
     # We visit in a fixed order but the important thing is we visit all items.
@@ -1600,7 +1835,11 @@ def _collect_actions_ordered(
             elif attr_name == "script":
                 sc_idx = script_counter[0]
                 script_counter[0] += 1
-                all_actions.append(_lower_script(item, ctx, origin, state_id, sc_idx))
+                result = _lower_script(item, ctx, origin, state_id, sc_idx)
+                if isinstance(result, list):
+                    all_actions.extend(result)
+                else:
+                    all_actions.append(result)
 
         return all_actions
 
@@ -1611,7 +1850,11 @@ def _collect_actions_ordered(
             if attr_name == "script":
                 sc_idx = script_counter[0]
                 script_counter[0] += 1
-                all_actions.append(_lower_script(item, ctx, origin, state_id, sc_idx))
+                result = _lower_script(item, ctx, origin, state_id, sc_idx)
+                if isinstance(result, list):
+                    all_actions.extend(result)
+                else:
+                    all_actions.append(result)
             else:
                 # Call the appropriate inline logic
                 if attr_name == "raise_value":
@@ -1692,11 +1935,26 @@ def _lower_invoke(
     child_machine: Optional[MachineIR] = None
     content_items = getattr(inv, "content", []) or []
     for content in content_items:
-        # Look for inline <scxml> inside <content>
+        # Look for inline <scxml> inside <content>.
+        # SCXMLDocumentHandler yields scjson.dataclasses.Scxml (not pydantic.Scxml),
+        # so we recognise either concrete class and also duck-type on the
+        # presence of ``state`` / ``datamodel`` / ``initial`` to catch any
+        # future representation that has the SCXML root interface (Fix 2).
         inner_list = getattr(content, "content", []) or []
         for inner in inner_list:
             from .pydantic import Scxml as _PydScxml
-            if isinstance(inner, _PydScxml):
+            from . import dataclasses as _dc_module
+            _DcScxml = getattr(_dc_module, "Scxml", None)
+            _is_inline_scxml = (
+                isinstance(inner, _PydScxml)
+                or (_DcScxml is not None and isinstance(inner, _DcScxml))
+                or (
+                    hasattr(inner, "state")
+                    and hasattr(inner, "datamodel")
+                    and hasattr(inner, "initial")
+                )
+            )
+            if _is_inline_scxml:
                 if ctx.invoke_depth >= _MAX_INVOKE_DEPTH:
                     diag = ExecutableDiagnostic(
                         code="invoke-depth-exceeded",

--- a/py/tests/fixtures/ecmascript_simple.scxml
+++ b/py/tests/fixtures/ecmascript_simple.scxml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <datamodel>
+    <data id="x" expr="0"/>
+    <data id="flag" expr="false"/>
+  </datamodel>
+  <state id="idle">
+    <!-- ECMAScript cond: x === 0 (strict equality) -->
+    <transition cond="x === 0" event="go" target="active"/>
+    <!-- ECMAScript cond: flag === false -->
+    <transition cond="flag === false &amp;&amp; x !== 1" event="go2" target="done"/>
+  </state>
+  <state id="active">
+    <!-- ECMAScript cond: x &gt; 0 || flag === true -->
+    <transition cond="x &gt; 0 || flag === true" event="finish" target="done"/>
+    <transition event="reset" target="idle"/>
+  </state>
+  <state id="done"/>
+</scxml>

--- a/py/tests/test_cli.py
+++ b/py/tests/test_cli.py
@@ -214,7 +214,11 @@ def test_document_context_datamodel_default():
 
 
 def test_document_context_invalid_datamodel():
-    """Creating a context with non-python datamodel should fail."""
-    doc = Scxml(state=[{"id": "a"}], datamodel_attribute="ecmascript", version=1.0)
+    """Creating a context with an unsupported datamodel should fail.
+
+    Note: ``ecmascript`` is now an admitted datamodel (M1P6 D-M1P6-1).
+    The test uses ``"xpath"`` as a truly unsupported value.
+    """
+    doc = Scxml(state=[{"id": "a"}], datamodel_attribute="xpath", version=1.0)
     with pytest.raises(ValueError):
         DocumentContext.from_doc(doc)

--- a/py/tests/test_ecmascript_engine.py
+++ b/py/tests/test_ecmascript_engine.py
@@ -1,0 +1,411 @@
+"""
+Agent Name: ecmascript-engine-tests
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+Integration tests for the constrained ECMAScript front-end in the engine
+(M1P6 G2).  Tests that:
+  - datamodel="ecmascript" machines load and execute.
+  - ECMAScript conditions (===, !==, &&, ||, !) are evaluated correctly.
+  - _event.name and _event.data are accessible in expressions.
+  - The Dining Philosophers single-philosopher child machine can step through
+    Thinking -> Hungry -> Eating using time advancement.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from decimal import Decimal
+
+import pytest
+
+from scjson.context import DocumentContext, ExecutionMode
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+DP_DIR = (
+    Path(__file__).parent.parent.parent
+    / "tutorial"
+    / "Examples"
+    / "StateCharts"
+    / "DiningPhilosphersProblem"
+)
+DP_SCXML = DP_DIR / "machine_dining_philosphers.scxml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(name: str) -> DocumentContext:
+    path = FIXTURES_DIR / name
+    return DocumentContext.from_xml_file(
+        str(path), execution_mode=ExecutionMode.LAX
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic ecmascript datamodel tests (using the fixture machine)
+# ---------------------------------------------------------------------------
+
+
+def test_ecmascript_machine_loads() -> None:
+    """A machine with datamodel=ecmascript loads without error."""
+    ctx = _load_fixture("ecmascript_simple.scxml")
+    assert "idle" in ctx.configuration
+
+
+def test_ecmascript_strict_equality_condition() -> None:
+    """A transition guarded by x === 0 fires when x == 0 (initial value)."""
+    ctx = _load_fixture("ecmascript_simple.scxml")
+    assert "idle" in ctx.configuration
+    # x is initialized to 0; transition cond is "x === 0"; event is "go"
+    ctx.enqueue("go")
+    ctx.microstep()
+    assert "active" in ctx.configuration, (
+        "Expected transition to 'active' via x === 0 condition; "
+        "configuration was {}".format(ctx.configuration)
+    )
+
+
+def test_ecmascript_logical_and_condition() -> None:
+    """A transition with flag === false && x !== 1 fires from idle."""
+    ctx = _load_fixture("ecmascript_simple.scxml")
+    ctx.enqueue("go2")
+    ctx.microstep()
+    assert "done" in ctx.configuration
+
+
+def test_ecmascript_logical_or_condition() -> None:
+    """A transition with x > 0 || flag === true fires when x > 0."""
+    ctx = _load_fixture("ecmascript_simple.scxml")
+    # First get to active state
+    ctx.enqueue("go")
+    ctx.microstep()
+    assert "active" in ctx.configuration
+    # Set x > 0 by modifying datamodel directly
+    ctx.data_model["x"] = 1
+    ctx.enqueue("finish")
+    ctx.microstep()
+    assert "done" in ctx.configuration
+
+
+def test_ecmascript_mode_flag_set() -> None:
+    """The _ecmascript_mode flag is True for ecmascript machines."""
+    ctx = _load_fixture("ecmascript_simple.scxml")
+    assert getattr(ctx, "_ecmascript_mode", False) is True
+
+
+def test_ecmascript_not_set_for_python_machines() -> None:
+    """Non-ecmascript machines do not have _ecmascript_mode set to True."""
+    from decimal import Decimal
+    from scjson.pydantic import Scxml, State, Transition
+    doc = Scxml(
+        initial=["a"],
+        state=[
+            State(id="a", transition=[Transition(event="go", target=["b"])]),
+            State(id="b"),
+        ],
+        version=Decimal("1.0"),
+    )
+    ctx = DocumentContext.from_doc(doc)
+    assert not getattr(ctx, "_ecmascript_mode", False)
+
+
+# ---------------------------------------------------------------------------
+# _event availability in ecmascript conditions
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_in_ecmascript_condition() -> None:
+    """_event.name is available in ECMAScript transition conditions."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <state id="idle">
+    <transition cond="_event.name === 'ping'" event="ping" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    ctx.enqueue("ping")
+    ctx.microstep()
+    assert "done" in ctx.configuration
+
+
+def test_event_data_in_ecmascript_condition() -> None:
+    """_event.data is available in ECMAScript transition conditions."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <state id="idle">
+    <transition cond="_event.data === 1" event="tick" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    from scjson.events import Event
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    ctx.events.push(Event(name="tick", data=1))
+    ctx.microstep()
+    assert "done" in ctx.configuration
+
+
+def test_event_data_false_does_not_fire() -> None:
+    """A transition with _event.data === 1 does NOT fire when data is 0."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <state id="idle">
+    <transition cond="_event.data === 1" event="tick" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    from scjson.events import Event
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    ctx.events.push(Event(name="tick", data=0))
+    ctx.microstep()
+    assert "idle" in ctx.configuration
+    assert "done" not in ctx.configuration
+
+
+# ---------------------------------------------------------------------------
+# ECMAScript eventexpr / targetexpr / delayexpr
+# ---------------------------------------------------------------------------
+
+
+def test_ecmascript_eventexpr() -> None:
+    """eventexpr with ECMAScript string concatenation works."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <datamodel>
+    <data id="myId" expr="5"/>
+  </datamodel>
+  <state id="idle">
+    <onentry>
+      <send eventexpr="'ping.' + myId"/>
+    </onentry>
+    <transition event="ping.5" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    ctx.microstep()
+    assert "done" in ctx.configuration
+
+
+def test_ecmascript_delayexpr() -> None:
+    """delayexpr with string concatenation (e.g., delay + 'ms') works."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <datamodel>
+    <data id="delay_ms" expr="100"/>
+  </datamodel>
+  <state id="idle">
+    <onentry>
+      <send event="tick" delayexpr="delay_ms + 'ms'" id="timer1"/>
+    </onentry>
+    <transition event="tick" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    # After initial entry, the delayed event should be pending
+    assert "idle" in ctx.configuration
+    assert ctx.delayed_events  # timer is scheduled
+    # Advance time to release it
+    ctx.advance_time(0.2)
+    ctx.microstep()
+    assert "done" in ctx.configuration
+
+
+# ---------------------------------------------------------------------------
+# ECMAScript <script> body execution
+# ---------------------------------------------------------------------------
+
+
+def test_ecmascript_script_assignment() -> None:
+    """A <script> body that assigns t_INPUTS[key] = val executes correctly."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <datamodel>
+    <data id="t_INPUTS" expr="{}"/>
+  </datamodel>
+  <state id="idle">
+    <transition event="assign_event" target="done">
+      <script>t_INPUTS['key1'] = 42</script>
+    </transition>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    ctx.enqueue("assign_event")
+    ctx.microstep()
+    assert "done" in ctx.configuration
+    t_inputs = ctx.data_model.get("t_INPUTS", {})
+    assert t_inputs.get("key1") == 42, (
+        "Expected t_INPUTS['key1'] == 42, got {}".format(t_inputs)
+    )
+
+
+def test_ecmascript_script_if_body() -> None:
+    """A <script> body with if (cond) { assign } executes the if branch."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <datamodel>
+    <data id="x" expr="5"/>
+    <data id="y" expr="0"/>
+  </datamodel>
+  <state id="idle">
+    <onentry>
+      <script>if (x !== 0) {
+    y = x + 1
+}</script>
+    </onentry>
+    <transition event="check" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    # x=5, y should become 6 after onentry script
+    assert ctx.data_model.get("y") == 6, (
+        "Expected y=6 after script; got y={}".format(ctx.data_model.get("y"))
+    )
+
+
+# ---------------------------------------------------------------------------
+# parseInt / String built-ins
+# ---------------------------------------------------------------------------
+
+
+def test_parse_int_in_cond() -> None:
+    """parseInt in a condition expression is evaluated correctly."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<scxml datamodel="ecmascript" initial="idle" version="1.0"
+       xmlns="http://www.w3.org/2005/07/scxml">
+  <state id="idle">
+    <transition cond="parseInt('42') === 42" event="go" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>"""
+    ctx = DocumentContext.from_xml_string(xml, execution_mode=ExecutionMode.LAX)
+    ctx.enqueue("go")
+    ctx.microstep()
+    assert "done" in ctx.configuration
+
+
+# ---------------------------------------------------------------------------
+# Dining Philosophers machine integration (child machine invoke, ecmascript)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not DP_SCXML.exists(),
+    reason="Dining Philosophers SCXML not found at expected path",
+)
+def test_dp_machine_loads() -> None:
+    """The Dining Philosophers SCXML loads; parallel root + 5 states entered."""
+    import json as _json
+    from scjson.SCXMLDocumentHandler import SCXMLDocumentHandler
+    from scjson.pydantic import Scxml
+    handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+    xml = DP_SCXML.read_text(encoding="utf-8-sig")
+    json_str = handler.xml_to_json(xml)
+    data = DocumentContext._prepare_raw_data(_json.loads(json_str))
+    doc = Scxml.model_validate(data)
+    ctx = DocumentContext._from_model(
+        doc, data,
+        allow_unsafe_eval=False, evaluator=None,
+        execution_mode=ExecutionMode.LAX,
+        source_xml=xml, base_dir=DP_DIR,
+        defer_initial=False,
+    )
+    assert "DiningPhilosophers" in ctx.configuration
+    thinking = [s for s in ctx.configuration if "Thinking" in s]
+    assert len(thinking) == 5, (
+        "Expected all 5 philosophers in Thinking; got {}".format(thinking)
+    )
+
+
+@pytest.mark.skipif(
+    not DP_SCXML.exists(),
+    reason="Dining Philosophers SCXML not found at expected path",
+)
+def test_dp_initial_configuration() -> None:
+    """All five philosophers start in Thinking; child machines have correct forks."""
+    import json as _json
+    from scjson.SCXMLDocumentHandler import SCXMLDocumentHandler
+    from scjson.pydantic import Scxml
+    handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+    xml = DP_SCXML.read_text(encoding="utf-8-sig")
+    json_str = handler.xml_to_json(xml)
+    data = DocumentContext._prepare_raw_data(_json.loads(json_str))
+    doc = Scxml.model_validate(data)
+    ctx = DocumentContext._from_model(
+        doc, data,
+        allow_unsafe_eval=False, evaluator=None,
+        execution_mode=ExecutionMode.LAX,
+        source_xml=xml, base_dir=DP_DIR,
+        defer_initial=False,
+    )
+    # Every child should be in Thinking state with correct fork assignment.
+    for n in range(1, 6):
+        inv = ctx.invocations.get("ID_P_{}".format(n))
+        assert inv is not None, "Invocation ID_P_{} missing".format(n)
+        child = getattr(inv, "child", None)
+        assert child is not None, "Child machine for ID_P_{} not created".format(n)
+        dm = child.data_model
+        assert dm.get("i_ID") == n, (
+            "P{} i_ID={} expected {}".format(n, dm.get("i_ID"), n)
+        )
+        # Verify onentry <script> executed: i_ID_LEFT / i_ID_RIGHT set from table
+        assert dm.get("i_ID_LEFT", 0) != 0, (
+            "P{} i_ID_LEFT not set by onentry script".format(n)
+        )
+        assert "Thinking" in child.configuration, (
+            "P{} not in Thinking state; config={}".format(n, child.configuration)
+        )
+
+
+@pytest.mark.skipif(
+    not DP_SCXML.exists(),
+    reason="Dining Philosophers SCXML not found at expected path",
+)
+def test_dp_child_philosopher_script_execution() -> None:
+    """The philosopher onentry <script> runs: i_ID_LEFT and i_ID_RIGHT are set."""
+    import json as _json
+    from scjson.SCXMLDocumentHandler import SCXMLDocumentHandler
+    from scjson.pydantic import Scxml
+    handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+    xml = DP_SCXML.read_text(encoding="utf-8-sig")
+    json_str = handler.xml_to_json(xml)
+    data = DocumentContext._prepare_raw_data(_json.loads(json_str))
+    doc = Scxml.model_validate(data)
+    ctx = DocumentContext._from_model(
+        doc, data,
+        allow_unsafe_eval=False, evaluator=None,
+        execution_mode=ExecutionMode.LAX,
+        source_xml=xml, base_dir=DP_DIR,
+        defer_initial=False,
+    )
+    # Philosopher 1 has forks 1 (left) and 5 (right) per the compliance table.
+    # [1,5], [2,1], [3,2], [4,3], [5,4]
+    expected_forks = {1: (1, 5), 2: (2, 1), 3: (3, 2), 4: (4, 3), 5: (5, 4)}
+    for n, (left, right) in expected_forks.items():
+        inv = ctx.invocations.get("ID_P_{}".format(n))
+        child = getattr(inv, "child", None) if inv else None
+        assert child is not None
+        dm = child.data_model
+        assert dm.get("i_ID_LEFT") == left, (
+            "P{} i_ID_LEFT expected {} got {}".format(n, left, dm.get("i_ID_LEFT"))
+        )
+        assert dm.get("i_ID_RIGHT") == right, (
+            "P{} i_ID_RIGHT expected {} got {}".format(n, right, dm.get("i_ID_RIGHT"))
+        )

--- a/py/tests/test_ecmascript_normalizer.py
+++ b/py/tests/test_ecmascript_normalizer.py
@@ -1,0 +1,428 @@
+"""
+Agent Name: ecmascript-normalizer-tests
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+Unit tests for the constrained ECMAScript normalizer (M1P6 D-M1P6-2).
+Each admitted form is tested for correct Python output; each inadmissible
+form is tested to confirm ECMAScriptNormalizationError is raised.
+"""
+
+import pytest
+
+from scjson.ecmascript_normalizer import (
+    ECMAScriptNormalizationError,
+    normalize,
+    normalize_script,
+)
+
+
+# ---------------------------------------------------------------------------
+# Admitted operator forms
+# ---------------------------------------------------------------------------
+
+
+def test_logical_and() -> None:
+    """&& is rewritten to 'and'."""
+    assert normalize("a && b") == "a  and  b"
+
+
+def test_logical_or() -> None:
+    """|| is rewritten to 'or'."""
+    assert normalize("a || b") == "a  or  b"
+
+
+def test_logical_not_simple() -> None:
+    """! is rewritten to 'not '."""
+    result = normalize("!x")
+    assert "not " in result and "x" in result
+
+
+def test_logical_not_complex() -> None:
+    """!expr in a parenthesized condition."""
+    result = normalize("!(x === 0)")
+    # Should contain 'not' and '==' (=== -> ==)
+    assert "not " in result
+    assert "==" in result
+
+
+def test_strict_equality() -> None:
+    """=== is rewritten to ==."""
+    result = normalize("a === b")
+    assert "==" in result
+    assert "===" not in result
+
+
+def test_strict_inequality() -> None:
+    """!== is rewritten to !=."""
+    result = normalize("a !== b")
+    assert "!=" in result
+    assert "!==" not in result
+
+
+def test_loose_equality_passthrough() -> None:
+    """Plain == passes through unchanged."""
+    result = normalize("a == b")
+    assert result == "a == b"
+
+
+def test_loose_inequality_passthrough() -> None:
+    """Plain != passes through unchanged."""
+    result = normalize("a != b")
+    assert result == "a != b"
+
+
+def test_comparison_operators() -> None:
+    """< <= > >= pass through unchanged."""
+    for op in ("<", "<=", ">", ">="):
+        result = normalize("a {} b".format(op))
+        assert op in result
+
+
+def test_arithmetic_passthrough() -> None:
+    """Arithmetic operators pass through."""
+    result = normalize("x + y * z - w / 2")
+    assert result == "x + y * z - w / 2"
+
+
+# ---------------------------------------------------------------------------
+# Literal forms
+# ---------------------------------------------------------------------------
+
+
+def test_true_literal() -> None:
+    """'true' is rewritten to 'True'."""
+    result = normalize("true")
+    assert result == "True"
+
+
+def test_false_literal() -> None:
+    """'false' is rewritten to 'False'."""
+    result = normalize("false")
+    assert result == "False"
+
+
+def test_null_literal() -> None:
+    """'null' is rewritten to 'None'."""
+    result = normalize("null")
+    assert result == "None"
+
+
+def test_undefined_literal() -> None:
+    """'undefined' is rewritten to 'None'."""
+    result = normalize("undefined")
+    assert result == "None"
+
+
+def test_number_literal() -> None:
+    """Number literals pass through unchanged."""
+    result = normalize("42")
+    assert result == "42"
+    result2 = normalize("3.14")
+    assert result2 == "3.14"
+
+
+def test_string_literal_single_quotes_preserved() -> None:
+    """Single-quoted strings are preserved as-is."""
+    result = normalize("'hello'")
+    assert result == "'hello'"
+
+
+def test_string_literal_content_not_mutated() -> None:
+    """String literals containing JS keywords are not substituted inside."""
+    result = normalize("'true && false || null'")
+    # The literal content must not be changed
+    assert result == "'true && false || null'"
+
+
+def test_true_in_string_not_replaced() -> None:
+    """'true' inside a string literal is not replaced with 'True'."""
+    result = normalize("x === 'true'")
+    # x === 'true' -> x == 'true'  (string content unchanged)
+    assert "==" in result
+    assert "'true'" in result
+    assert "True" not in result
+
+
+# ---------------------------------------------------------------------------
+# Built-in function rewrites
+# ---------------------------------------------------------------------------
+
+
+def test_parse_int_no_radix() -> None:
+    """parseInt(x) is rewritten to int(x)."""
+    result = normalize("parseInt(x)")
+    assert result == "int(x)"
+
+
+def test_parse_int_with_radix() -> None:
+    """parseInt(x, r) is rewritten to int(x, r)."""
+    result = normalize("parseInt(x, 10)")
+    assert result == "int(x, 10)"
+
+
+def test_parse_int_with_expression() -> None:
+    """parseInt with a method call expression (DP machine pattern)."""
+    result = normalize("parseInt(_event.name.replace('taken.',''))")
+    # replace method is Python-compatible, parseInt -> int
+    assert result.startswith("int(")
+    assert "_event.name.replace" in result
+
+
+def test_string_coerce() -> None:
+    """String(x) is rewritten to str(x)."""
+    result = normalize("String(x)")
+    assert result == "str(x)"
+
+
+def test_number_coerce() -> None:
+    """Number(x) is rewritten to float(x)."""
+    result = normalize("Number(x)")
+    assert result == "float(x)"
+
+
+def test_replace_passthrough() -> None:
+    """str.replace is already Python-compatible and passes through."""
+    result = normalize("name.replace('taken.', '')")
+    assert "replace" in result
+
+
+# ---------------------------------------------------------------------------
+# System variable access
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_passthrough() -> None:
+    """_event.name passes through unchanged."""
+    result = normalize("_event.name")
+    assert result == "_event.name"
+
+
+def test_event_data_passthrough() -> None:
+    """_event.data passes through unchanged."""
+    result = normalize("_event.data")
+    assert result == "_event.data"
+
+
+def test_computed_dict_access() -> None:
+    """dict[key] computed access passes through."""
+    result = normalize("t_INPUTS[_event.name]")
+    assert result == "t_INPUTS[_event.name]"
+
+
+# ---------------------------------------------------------------------------
+# Object / array literals
+# ---------------------------------------------------------------------------
+
+
+def test_object_literal_unquoted_keys() -> None:
+    """JS object literal with unquoted keys is converted to Python dict."""
+    result = normalize("{ foo: 1, bar: 2 }")
+    assert '"foo"' in result or "'foo'" in result
+    assert '"bar"' in result or "'bar'" in result
+
+
+def test_object_literal_already_quoted_keys() -> None:
+    """Object literal with already-quoted keys passes through."""
+    result = normalize("{ 'foo': 1 }")
+    # Should not double-quote
+    assert "'foo'" in result or '"foo"' in result
+
+
+def test_array_literal_passthrough() -> None:
+    """Array literals pass through unchanged."""
+    result = normalize("[1, 2, 3]")
+    assert result == "[1, 2, 3]"
+
+
+def test_array_of_arrays_passthrough() -> None:
+    """Array-of-array literals pass through unchanged."""
+    result = normalize("[[1, 5], [2, 1]]")
+    assert result == "[[1, 5], [2, 1]]"
+
+
+# ---------------------------------------------------------------------------
+# Comment stripping
+# ---------------------------------------------------------------------------
+
+
+def test_line_comment_stripped() -> None:
+    """// comments are removed before evaluation."""
+    result = normalize("x > 0 // check positive")
+    assert "//" not in result
+    assert "x > 0" in result
+
+
+def test_block_comment_stripped() -> None:
+    """/* ... */ comments are removed."""
+    result = normalize("x /* the value */ > 0")
+    assert "/*" not in result
+    assert "x" in result
+    assert "> 0" in result
+
+
+# ---------------------------------------------------------------------------
+# Complex compound expressions (DP machine patterns)
+# ---------------------------------------------------------------------------
+
+
+def test_dp_condition_or() -> None:
+    """DP machine condition: (_event.name == expr) || (_event.name == expr2)."""
+    expr = "(_event.name == ('taken.' + i_ID_LEFT)) || (_event.name == ('taken.' + i_ID_RIGHT))"
+    result = normalize(expr)
+    assert " or " in result
+    assert "_event.name" in result
+
+
+def test_dp_delay_concatenation() -> None:
+    """DP machine delay: i_DELAY_THINK_EAT + 'ms'."""
+    result = normalize("i_DELAY_THINK_EAT + 'ms'")
+    assert "i_DELAY_THINK_EAT" in result
+    assert "'ms'" in result
+
+
+def test_dp_event_name_send() -> None:
+    """DP machine eventexpr: 'eat.' + i_ID."""
+    result = normalize("'eat.' + i_ID")
+    assert "'eat.'" in result
+    assert "i_ID" in result
+
+
+def test_dp_not_condition() -> None:
+    """DP machine: ! (_event.data==1) -> not (_event.data==1)."""
+    result = normalize("! (_event.data==1)")
+    assert "not " in result
+    assert "_event.data" in result
+
+
+def test_dp_target_expr() -> None:
+    """DP machine targetexpr: '#_ID_P_' + (complianceIndex + 1)."""
+    result = normalize("'#_ID_P_' + (complianceIndex + 1)")
+    assert "'#_ID_P_'" in result
+
+
+# ---------------------------------------------------------------------------
+# Inadmissible forms (must raise ECMAScriptNormalizationError)
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_arrow_function() -> None:
+    """Arrow functions raise ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("x => x + 1")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+    assert "arrow function" in str(exc_info.value)
+
+
+def test_unsupported_new() -> None:
+    """'new' expression raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("new Object()")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_typeof() -> None:
+    """typeof operator raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("typeof x === 'number'")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_instanceof() -> None:
+    """instanceof operator raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("x instanceof Array")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_for_loop() -> None:
+    """for loop raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("for (let i = 0; i < 10; i++) {}")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_while_loop() -> None:
+    """while loop raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("while (x > 0) { x-- }")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_template_literal() -> None:
+    """Template literals raise ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("`hello ${name}`")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_delete() -> None:
+    """delete operator raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("delete obj.key")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_void() -> None:
+    """void operator raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("void 0")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_yield() -> None:
+    """yield raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("yield x")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+def test_unsupported_await() -> None:
+    """await raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError) as exc_info:
+        normalize("await somePromise")
+    assert exc_info.value.diagnostic == "unsupported-ecmascript"
+
+
+# ---------------------------------------------------------------------------
+# Script body normalization
+# ---------------------------------------------------------------------------
+
+
+def test_script_assignment() -> None:
+    """Simple assignment in a script body normalizes correctly."""
+    result = normalize_script("t_INPUTS[_event.name] = _event.data")
+    assert "t_INPUTS[_event.name]" in result
+    assert "_event.data" in result
+
+
+def test_script_if_statement() -> None:
+    """if (cond) { body } is converted to Python if form."""
+    result = normalize_script("if (i_ID !== 0) {\n    x = 1\n}")
+    assert result.startswith("if ")
+    assert "!=" in result  # !== -> !=
+    assert "x = 1" in result
+
+
+def test_script_if_with_assignments() -> None:
+    """Multi-line if body with assignments (DP machine pattern)."""
+    body = """if (i_ID !== 0) {
+    i_ID_LEFT = t_HAND_COMPLIANCE[i_ID - 1][0]
+    i_ID_RIGHT = t_HAND_COMPLIANCE[i_ID - 1][1]
+}
+
+t_INPUTS['taken.' + i_ID_LEFT] = 0
+t_INPUTS['taken.' + i_ID_RIGHT] = 0"""
+    result = normalize_script(body)
+    assert "if " in result
+    assert "i_ID_LEFT" in result
+    assert "i_ID_RIGHT" in result
+    assert "t_INPUTS" in result
+
+
+def test_script_unsupported_form_raises() -> None:
+    """Inadmissible form in a script body raises ECMAScriptNormalizationError."""
+    with pytest.raises(ECMAScriptNormalizationError):
+        normalize_script("for (let i = 0; i < 10; i++) { x += i }")

--- a/py/tests/test_exec_ir.py
+++ b/py/tests/test_exec_ir.py
@@ -1,0 +1,1168 @@
+"""
+Agent Name: test-exec-ir
+
+Part of the scjson project.
+Developed by Softoboros Technology Inc.
+Licensed under the BSD 1-Clause License.
+
+Tests for the M1 Executable IR module (exec_ir.py) and the SCJSON→IR lowerer.
+
+Coverage:
+- All admitted ECMAScript expression forms (D-M1P6-2) → ExpressionNode
+- All ActionNode kinds (M1-EXECUTABLE-IR Area 2)
+- At least one unsupported-ecmascript diagnostic case (arrow fn) → no crash
+- Dining Philosophers lowering proof (keystone)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import pytest
+
+# Ensure the py/ package is on the path when running from the repo root.
+_here = os.path.dirname(__file__)
+_pkg_root = os.path.join(_here, "..")
+if _pkg_root not in sys.path:
+    sys.path.insert(0, _pkg_root)
+
+from scjson.exec_ir import (
+    # Value types
+    NumberValue,
+    StrValue,
+    BoolValue,
+    ArrayValue,
+    MapValue,
+    UndefinedValue,
+    # ExpressionNode families
+    NumericLiteral,
+    StringLiteral,
+    BoolLiteral,
+    VarRead,
+    MemberAccess,
+    IndexAccess,
+    BinOp,
+    UnaryOp,
+    CallNode,
+    ArrayLiteral,
+    MapLiteral,
+    UnsupportedExpr,
+    # ActionNode families
+    AssignNode,
+    LogNode,
+    RaiseNode,
+    SendNode,
+    CancelNode,
+    IfNode,
+    IfBranch,
+    ForeachNode,
+    CapabilityCallNode,
+    # Diagnostics
+    ExecutableDiagnostic,
+    # State-tree IR
+    MachineIR,
+    StateIR,
+    ParallelIR,
+    FinalIR,
+    HistoryIR,
+    InvokeIR,
+    TransitionIR,
+    DataSlotIR,
+    OriginRef,
+    # Lower API
+    lower_expression,
+    lower_document,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SCJSON_ROOT = os.path.abspath(os.path.join(_here, "..", ".."))
+DP_SCXML_PATH = os.path.join(
+    _SCJSON_ROOT, "tutorial", "Examples", "StateCharts",
+    "DiningPhilosphersProblem", "machine_dining_philosphers.flat.scxml",
+)
+
+
+def _parse_dp() -> object:
+    """Load and parse the Dining Philosophers SCXML file into a Pydantic model."""
+    from scjson.context import DocumentContext
+    from scjson.SCXMLDocumentHandler import SCXMLDocumentHandler
+    from scjson.pydantic import Scxml
+    import json
+
+    xml_str = open(DP_SCXML_PATH, encoding="utf-8").read()
+    handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+    json_str = handler.xml_to_json(xml_str)
+    data = DocumentContext._prepare_raw_data(json.loads(json_str))
+    return Scxml.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Expression lowering — admitted ECMAScript subset (D-M1P6-2)
+# ---------------------------------------------------------------------------
+
+class TestExpressionLowering:
+    """Each admitted ECMAScript form maps to the expected ExpressionNode."""
+
+    def test_integer_literal(self):
+        node, diags = lower_expression("42", "test")
+        assert isinstance(node, NumericLiteral)
+        assert node.num == 42
+        assert not diags
+
+    def test_float_literal(self):
+        node, diags = lower_expression("3.14", "test")
+        assert isinstance(node, NumericLiteral)
+        assert abs(node.num - 3.14) < 1e-9
+        assert not diags
+
+    def test_negative_integer(self):
+        node, diags = lower_expression("-5", "test")
+        # -5 parses as UnaryOp(neg, 5) or as a signed constant depending on Python version
+        assert isinstance(node, (NumericLiteral, UnaryOp))
+        assert not diags
+
+    def test_string_literal(self):
+        node, diags = lower_expression("'hello'", "test")
+        assert isinstance(node, StringLiteral)
+        assert node.s == "hello"
+        assert not diags
+
+    def test_true_literal(self):
+        node, diags = lower_expression("true", "test")
+        assert isinstance(node, BoolLiteral)
+        assert node.b is True
+        assert not diags
+
+    def test_false_literal(self):
+        node, diags = lower_expression("false", "test")
+        assert isinstance(node, BoolLiteral)
+        assert node.b is False
+        assert not diags
+
+    def test_var_read(self):
+        node, diags = lower_expression("i_ID", "test")
+        assert isinstance(node, VarRead)
+        assert node.var == "i_ID"
+        assert not diags
+
+    def test_member_access_event_name(self):
+        node, diags = lower_expression("_event.name", "test")
+        assert isinstance(node, MemberAccess)
+        assert isinstance(node.obj, VarRead)
+        assert node.obj.var == "_event"
+        assert node.attr == "name"
+        assert not diags
+
+    def test_member_access_event_data(self):
+        node, diags = lower_expression("_event.data", "test")
+        assert isinstance(node, MemberAccess)
+        assert node.attr == "data"
+        assert not diags
+
+    def test_computed_index_access(self):
+        node, diags = lower_expression("t_INPUTS[_event.name]", "test")
+        assert isinstance(node, IndexAccess)
+        assert isinstance(node.obj, VarRead)
+        assert node.obj.var == "t_INPUTS"
+        assert isinstance(node.index, MemberAccess)
+        assert node.index.attr == "name"
+        assert not diags
+
+    def test_array_index_access(self):
+        node, diags = lower_expression("t_HAND_COMPLIANCE[0]", "test")
+        assert isinstance(node, IndexAccess)
+        assert isinstance(node.index, NumericLiteral)
+        assert node.index.num == 0
+        assert not diags
+
+    def test_addition(self):
+        node, diags = lower_expression("i_EAT_COUNT + 1", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "+"
+        assert isinstance(node.lhs, VarRead)
+        assert isinstance(node.rhs, NumericLiteral)
+        assert not diags
+
+    def test_multiplication(self):
+        node, diags = lower_expression("a * b", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "*"
+        assert not diags
+
+    def test_equality(self):
+        node, diags = lower_expression("t_INPUTS['taken.1']==0", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "=="
+        assert not diags
+
+    def test_strict_equality_maps_to_equality(self):
+        # === is normalized to == by the ecmascript_normalizer
+        node, diags = lower_expression("i_ID !== 0", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "!="
+        assert not diags
+
+    def test_comparison_lt(self):
+        node, diags = lower_expression("a < b", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "<"
+        assert not diags
+
+    def test_logical_and(self):
+        node, diags = lower_expression("a == 1 && b == 2", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "&&"
+        assert not diags
+
+    def test_logical_or(self):
+        node, diags = lower_expression("a || b", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "||"
+        assert not diags
+
+    def test_logical_not(self):
+        node, diags = lower_expression("!x", "test")
+        assert isinstance(node, UnaryOp)
+        assert node.op == "not"
+        assert isinstance(node.operand, VarRead)
+        assert not diags
+
+    def test_unary_not_of_comparison(self):
+        # ! (expr == 1)
+        node, diags = lower_expression("! (_event.data==1)", "test")
+        assert isinstance(node, UnaryOp)
+        assert node.op == "not"
+        assert not diags
+
+    def test_parseint(self):
+        node, diags = lower_expression("parseInt('5')", "test")
+        assert isinstance(node, CallNode)
+        assert node.func == "int"
+        assert not diags
+
+    def test_string_coerce(self):
+        node, diags = lower_expression("String(x)", "test")
+        assert isinstance(node, CallNode)
+        assert node.func == "str"
+        assert not diags
+
+    def test_number_coerce(self):
+        node, diags = lower_expression("Number(x)", "test")
+        assert isinstance(node, CallNode)
+        assert node.func == "float"
+        assert not diags
+
+    def test_str_replace_method(self):
+        node, diags = lower_expression("_event.name.replace('taken.','')", "test")
+        assert isinstance(node, CallNode)
+        assert node.func == "replace"
+        assert node.receiver is not None
+        assert not diags
+
+    def test_parseint_with_replace(self):
+        """Covers the key DP expression parseInt(_event.name.replace('taken.',''))."""
+        node, diags = lower_expression(
+            "parseInt(_event.name.replace('taken.',''))", "test"
+        )
+        assert isinstance(node, CallNode)
+        assert node.func == "int"
+        assert len(node.args) == 1
+        assert isinstance(node.args[0], CallNode)
+        assert node.args[0].func == "replace"
+        assert not diags
+
+    def test_string_concatenation_with_expr(self):
+        """i_DELAY_THINK_EAT + 'ms' — string concat with coercion."""
+        node, diags = lower_expression("i_DELAY_THINK_EAT + 'ms'", "test")
+        # The normalizer wraps the non-string side in str(); we should get
+        # a BinOp with a CallNode(str) on the lhs.
+        assert isinstance(node, BinOp)
+        assert node.op == "+"
+        assert not diags
+
+    def test_array_literal(self):
+        node, diags = lower_expression("[1, 2, 3]", "test")
+        assert isinstance(node, ArrayLiteral)
+        assert len(node.items) == 3
+        assert not diags
+
+    def test_array_of_array(self):
+        node, diags = lower_expression("[[1,5],[2,1]]", "test")
+        assert isinstance(node, ArrayLiteral)
+        assert len(node.items) == 2
+        assert isinstance(node.items[0], ArrayLiteral)
+        assert not diags
+
+    def test_object_literal(self):
+        node, diags = lower_expression(
+            "{ 'take.1':0, 'take.2':0 }", "test"
+        )
+        assert isinstance(node, MapLiteral)
+        assert len(node.entries) == 2
+        assert not diags
+
+    def test_event_name_string_comparison(self):
+        """_event.name == 'taken.' + i_ID_LEFT"""
+        node, diags = lower_expression(
+            "_event.name == ('taken.' + i_ID_LEFT)", "test"
+        )
+        assert isinstance(node, BinOp)
+        assert node.op == "=="
+        assert isinstance(node.lhs, MemberAccess)
+        assert not diags
+
+    def test_complex_dp_cond(self):
+        """Full DP child transition condition."""
+        expr = "(_event.name == ('taken.' + i_ID_LEFT)) || (_event.name == ('taken.' + i_ID_RIGHT))"
+        node, diags = lower_expression(expr, "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "||"
+        assert not diags
+
+    def test_t_inputs_computed_key_cond(self):
+        """t_INPUTS['taken.'+i_ID_LEFT]==0"""
+        node, diags = lower_expression(
+            "t_INPUTS['taken.'+i_ID_LEFT]==0", "test"
+        )
+        assert isinstance(node, BinOp)
+        assert node.op == "=="
+        assert isinstance(node.lhs, IndexAccess)
+        assert not diags
+
+    def test_t_inputs_indexed_by_event_name(self):
+        """t_INPUTS[_event.name] — the DP dispatch key expression."""
+        node, diags = lower_expression("t_INPUTS[_event.name]", "test")
+        assert isinstance(node, IndexAccess)
+        assert isinstance(node.index, MemberAccess)
+        assert node.index.attr == "name"
+        assert not diags
+
+    def test_complianceindex_add(self):
+        """complianceIndex + 1 — arithmetic in the DP foreach."""
+        node, diags = lower_expression("complianceIndex + 1", "test")
+        assert isinstance(node, BinOp)
+        assert node.op == "+"
+        assert not diags
+
+
+# ---------------------------------------------------------------------------
+# Unsupported expression forms (D-M1P6-8) — diagnostic, no crash
+# ---------------------------------------------------------------------------
+
+class TestUnsupportedExpressions:
+    """Inadmissible forms produce UnsupportedExpr + diagnostic, not a crash."""
+
+    def test_arrow_function_produces_diagnostic(self):
+        node, diags = lower_expression("(x) => x + 1", "test")
+        assert isinstance(node, UnsupportedExpr)
+        assert len(diags) == 1
+        assert diags[0].code == "unsupported-ecmascript"
+
+    def test_new_keyword_produces_diagnostic(self):
+        node, diags = lower_expression("new Foo()", "test")
+        assert isinstance(node, UnsupportedExpr)
+        assert len(diags) == 1
+        assert "unsupported-ecmascript" in diags[0].code
+
+    def test_typeof_produces_diagnostic(self):
+        node, diags = lower_expression("typeof x", "test")
+        assert isinstance(node, UnsupportedExpr)
+        assert diags
+
+    def test_template_literal_produces_diagnostic(self):
+        node, diags = lower_expression("`hello ${x}`", "test")
+        assert isinstance(node, UnsupportedExpr)
+        assert diags
+
+    def test_non_admitted_free_call_produces_diagnostic(self):
+        node, diags = lower_expression("Math.floor(x)", "test")
+        # Math.floor is a method call with non-admitted method name
+        assert isinstance(node, UnsupportedExpr)
+        assert diags
+
+    def test_diagnostic_never_raises(self):
+        # Extreme case: empty string
+        node, diags = lower_expression("", "test")
+        assert isinstance(node, UnsupportedExpr)
+        assert diags
+
+
+# ---------------------------------------------------------------------------
+# ActionNode construction tests
+# ---------------------------------------------------------------------------
+
+class TestActionNodes:
+    """Verify ActionNode dataclasses construct correctly."""
+
+    def test_assign_node(self):
+        n = AssignNode(
+            loc="i_EAT_COUNT",
+            expr=BinOp(op="+", lhs=VarRead(var="i_EAT_COUNT"), rhs=NumericLiteral(num=1)),
+            op="set",
+        )
+        assert n.loc == "i_EAT_COUNT"
+        assert n.op == "set"
+        assert isinstance(n.expr, BinOp)
+
+    def test_log_node(self):
+        n = LogNode(
+            expr=StringLiteral(s="hello"),
+            label="DEBUG",
+        )
+        assert n.label == "DEBUG"
+        assert isinstance(n.expr, StringLiteral)
+
+    def test_raise_node(self):
+        n = RaiseNode(event="error.execution")
+        assert n.event == "error.execution"
+
+    def test_send_node_static(self):
+        n = SendNode(event="take.1", target="#_parent")
+        assert n.event == "take.1"
+        assert n.target == "#_parent"
+        assert n.eventexpr is None
+
+    def test_send_node_dynamic(self):
+        n = SendNode(
+            eventexpr=MemberAccess(obj=VarRead(var="_event"), attr="name"),
+            targetexpr=StringLiteral(s="#_parent"),
+        )
+        assert n.event is None
+        assert isinstance(n.eventexpr, MemberAccess)
+
+    def test_cancel_node(self):
+        n = CancelNode(sendid="ID.Do.Timer.Think")
+        assert n.sendid == "ID.Do.Timer.Think"
+
+    def test_if_node(self):
+        guard = BinOp(op="==", lhs=VarRead(var="x"), rhs=NumericLiteral(num=0))
+        branch = IfBranch(guard=guard, body=[RaiseNode(event="done")])
+        n = IfNode(branches=[branch])
+        assert len(n.branches) == 1
+        assert isinstance(n.branches[0].guard, BinOp)
+
+    def test_foreach_node(self):
+        n = ForeachNode(
+            array_expr=VarRead(var="t_HAND_COMPLIANCE"),
+            item="complianceItem",
+            index="complianceIndex",
+            body=[LogNode(expr=VarRead(var="complianceItem"))],
+        )
+        assert n.item == "complianceItem"
+        assert n.index == "complianceIndex"
+        assert len(n.body) == 1
+
+    def test_capability_call_node(self):
+        origin = OriginRef(type="script", state="Thinking", idx=0)
+        n = CapabilityCallNode(
+            name="script_onentry_Thinking_0_0",
+            origin=origin,
+            success_event="script_onentry_Thinking_0_0.success",
+            error_event="script_onentry_Thinking_0_0.error",
+        )
+        assert n.success_event.endswith(".success")
+        assert n.error_event.endswith(".error")
+        assert n.capability_intent is None
+        assert n.args is None
+        assert n.return_type is None
+        assert n.correlation_id is None
+
+
+# ---------------------------------------------------------------------------
+# Value model tests (D-M1P6-3)
+# ---------------------------------------------------------------------------
+
+class TestValueModel:
+    """Tagged value types construct correctly."""
+
+    def test_number_value(self):
+        v = NumberValue(v=42)
+        assert v.v == 42
+
+    def test_str_value(self):
+        v = StrValue(v="hello")
+        assert v.v == "hello"
+
+    def test_bool_value(self):
+        v = BoolValue(v=True)
+        assert v.v is True
+
+    def test_array_value(self):
+        v = ArrayValue(items=[NumberValue(v=1), NumberValue(v=2)])
+        assert len(v.items) == 2
+
+    def test_map_value(self):
+        v = MapValue(entries=[("take.1", NumberValue(v=0))])
+        assert v.entries[0][0] == "take.1"
+
+    def test_undefined_value(self):
+        v = UndefinedValue()
+        assert isinstance(v, UndefinedValue)
+
+
+# ---------------------------------------------------------------------------
+# Dining Philosophers lowering proof (keystone test)
+# ---------------------------------------------------------------------------
+
+class TestDiningPhilosophersLowering:
+    """Full lowering proof for the DP machine.
+
+    Proves that lower_document() faithfully converts the flat SCXML to a
+    MachineIR with complete structural coverage.
+    """
+
+    @pytest.fixture(scope="class")
+    def dp_doc(self):
+        return _parse_dp()
+
+    @pytest.fixture(scope="class")
+    def dp_ir(self, dp_doc):
+        machine, diagnostics = lower_document(dp_doc)
+        return machine, diagnostics
+
+    def test_returns_machine_ir(self, dp_ir):
+        machine, _ = dp_ir
+        assert isinstance(machine, MachineIR)
+
+    def test_datamodel_attr_ecmascript(self, dp_ir):
+        machine, _ = dp_ir
+        assert machine.datamodel_attr == "ecmascript"
+
+    def test_root_is_parallel(self, dp_ir):
+        """The root <parallel id="DiningPhilosophers"> must be present."""
+        machine, _ = dp_ir
+        assert len(machine.children) == 1
+        root = machine.children[0]
+        assert isinstance(root, ParallelIR)
+        assert root.id == "DiningPhilosophers"
+
+    def test_parallel_has_correct_child_count(self, dp_ir):
+        """DiningPhilosophers has 5 Philosopher states + 5 Fork states = 10 children."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        assert isinstance(root, ParallelIR)
+        # 5 Philosopher states + 5 Fork states
+        assert len(root.children) == 10
+
+    def test_philosopher_states_present(self, dp_ir):
+        """Philosopher1..5 must all be StateIR nodes."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        phil_ids = {c.id for c in root.children if isinstance(c, StateIR)}
+        for n in range(1, 6):
+            assert "Philosopher{}".format(n) in phil_ids, \
+                "Philosopher{} missing from parallel children".format(n)
+
+    def test_fork_states_present(self, dp_ir):
+        """Fork1..5 must all be StateIR nodes."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        fork_ids = {c.id for c in root.children if isinstance(c, StateIR)}
+        for n in range(1, 6):
+            assert "Fork{}".format(n) in fork_ids, \
+                "Fork{} missing from parallel children".format(n)
+
+    def _collect_states(self, node, seen=None):
+        if seen is None:
+            seen = set()
+        if isinstance(node, MachineIR):
+            for c in node.children:
+                self._collect_states(c, seen)
+        elif isinstance(node, (StateIR, ParallelIR)):
+            seen.add(node.id)
+            for c in node.children:
+                self._collect_states(c, seen)
+            for inv in getattr(node, "invokes", []):
+                if inv.child_machine is not None:
+                    self._collect_states(inv.child_machine, seen)
+        elif isinstance(node, FinalIR):
+            seen.add(node.id)
+        return seen
+
+    def test_total_state_count(self, dp_ir):
+        """Total state count (including nested child machines) must cover all states.
+
+        The flat SCXML has:
+        - 1 parallel root (DiningPhilosophers)
+        - 5 philosopher observer states (PhilosopherN with 3 sub-states each)
+        - 5 fork states (ForkN with 2 sub-states each)
+        - 5 child machines (one per invoke), each with Philospher + sub-states +
+          ProcessHungry + sub-states + FinalSub
+
+        We verify > 50 states (the structure is large).
+        """
+        machine, _ = dp_ir
+        all_states = self._collect_states(machine)
+        assert len(all_states) > 50, \
+            "Expected > 50 states across all machines; got {}".format(len(all_states))
+
+    def test_philosopher_nested_states(self, dp_ir):
+        """Each Philosopher state must have nested P{N}_Thinking/Hungry/Eating children."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        for child in root.children:
+            if not isinstance(child, StateIR):
+                continue
+            if not child.id.startswith("Philosopher"):
+                continue
+            n = child.id.replace("Philosopher", "")
+            child_ids = {c.id for c in child.children}
+            for sub in ("P{}_Thinking".format(n), "P{}_Hungry".format(n)):
+                assert sub in child_ids, \
+                    "{} missing from {}".format(sub, child.id)
+
+    def test_five_invoke_child_machines(self, dp_ir):
+        """Each PhilosopherN must have exactly one InvokeIR with a child MachineIR."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        invoke_count = 0
+        for child in root.children:
+            if not isinstance(child, StateIR):
+                continue
+            if not child.id.startswith("Philosopher"):
+                continue
+            assert len(child.invokes) == 1, \
+                "{} must have exactly 1 invoke; got {}".format(child.id, len(child.invokes))
+            inv = child.invokes[0]
+            assert inv.child_machine is not None, \
+                "{}'s invoke has no child_machine".format(child.id)
+            assert isinstance(inv.child_machine, MachineIR)
+            invoke_count += 1
+        assert invoke_count == 5
+
+    def test_child_machine_has_philospher_state(self, dp_ir):
+        """Each child machine must contain a 'Philospher' state with sub-states."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        for child in root.children:
+            if not isinstance(child, StateIR) or not child.id.startswith("Philosopher"):
+                continue
+            cm = child.invokes[0].child_machine
+            assert cm is not None
+            child_state_ids = {c.id for c in cm.children}
+            assert "Philospher" in child_state_ids or "FinalSub" in child_state_ids, \
+                "Child machine for {} missing expected states; got {}".format(
+                    child.id, child_state_ids
+                )
+
+    def _count_transitions(self, node):
+        count = 0
+        if isinstance(node, MachineIR):
+            for c in node.children:
+                count += self._count_transitions(c)
+        elif isinstance(node, (StateIR, ParallelIR)):
+            count += len(node.transitions)
+            for c in node.children:
+                count += self._count_transitions(c)
+            for inv in getattr(node, "invokes", []):
+                if inv.child_machine is not None:
+                    count += self._count_transitions(inv.child_machine)
+        return count
+
+    def test_transition_count(self, dp_ir):
+        """Total transition count must be substantial (>80 across all machines)."""
+        machine, _ = dp_ir
+        total = self._count_transitions(machine)
+        assert total > 80, "Expected > 80 transitions; got {}".format(total)
+
+    def _count_datamodel_slots(self, node):
+        count = 0
+        if isinstance(node, MachineIR):
+            count += len(node.datamodel)
+            for c in node.children:
+                count += self._count_datamodel_slots(c)
+        elif isinstance(node, (StateIR, ParallelIR)):
+            count += len(node.datamodel)
+            for c in node.children:
+                count += self._count_datamodel_slots(c)
+            for inv in getattr(node, "invokes", []):
+                if inv.child_machine is not None:
+                    count += self._count_datamodel_slots(inv.child_machine)
+        return count
+
+    def test_datamodel_slot_count(self, dp_ir):
+        """Total datamodel slot count must be substantial (>15)."""
+        machine, _ = dp_ir
+        total = self._count_datamodel_slots(machine)
+        assert total > 15, "Expected > 15 datamodel slots; got {}".format(total)
+
+    def test_root_datamodel_slots(self, dp_ir):
+        """Root parallel must have t_INPUTS, t_HAND_COMPLIANCE, i_DELAY_THINK_EAT."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        assert isinstance(root, ParallelIR)
+        slot_ids = {s.id for s in root.datamodel}
+        assert "t_INPUTS" in slot_ids
+        assert "t_HAND_COMPLIANCE" in slot_ids
+        assert "i_DELAY_THINK_EAT" in slot_ids
+
+    def test_t_inputs_lowered_as_map(self, dp_ir):
+        """t_INPUTS initial value must lower to a MapValue."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        assert isinstance(root, ParallelIR)
+        t_inputs = next((s for s in root.datamodel if s.id == "t_INPUTS"), None)
+        assert t_inputs is not None
+        assert isinstance(t_inputs.initial_value, MapValue), \
+            "t_INPUTS initial_value expected MapValue; got {}".format(
+                type(t_inputs.initial_value).__name__
+            )
+
+    def test_t_hand_compliance_lowered_as_array(self, dp_ir):
+        """t_HAND_COMPLIANCE must lower to an ArrayValue (array of arrays)."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        slot = next((s for s in root.datamodel if s.id == "t_HAND_COMPLIANCE"), None)
+        assert slot is not None
+        assert isinstance(slot.initial_value, ArrayValue), \
+            "t_HAND_COMPLIANCE expected ArrayValue; got {}".format(
+                type(slot.initial_value).__name__
+            )
+        # Should be 5 inner arrays (one per philosopher)
+        assert len(slot.initial_value.items) == 5
+
+    def test_i_delay_lowered_as_number(self, dp_ir):
+        """i_DELAY_THINK_EAT must lower to NumberValue(1000)."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        slot = next((s for s in root.datamodel if s.id == "i_DELAY_THINK_EAT"), None)
+        assert slot is not None
+        assert isinstance(slot.initial_value, NumberValue)
+        assert slot.initial_value.v == 1000
+
+    def _find_expr_in_ir(self, node, pred):
+        """Recursively search for any ExpressionNode satisfying pred."""
+        if pred(node):
+            return node
+        if isinstance(node, BinOp):
+            r = self._find_expr_in_ir(node.lhs, pred) or self._find_expr_in_ir(node.rhs, pred)
+            if r:
+                return r
+        if isinstance(node, UnaryOp):
+            r = self._find_expr_in_ir(node.operand, pred)
+            if r:
+                return r
+        if isinstance(node, (MemberAccess, IndexAccess)):
+            r = self._find_expr_in_ir(node.obj, pred)
+            if r:
+                return r
+            if isinstance(node, IndexAccess):
+                r = self._find_expr_in_ir(node.index, pred)
+                if r:
+                    return r
+        if isinstance(node, CallNode):
+            if node.receiver:
+                r = self._find_expr_in_ir(node.receiver, pred)
+                if r:
+                    return r
+            for a in node.args:
+                r = self._find_expr_in_ir(a, pred)
+                if r:
+                    return r
+        if isinstance(node, (ArrayLiteral, MapLiteral)):
+            for item in (node.items if isinstance(node, ArrayLiteral) else [v for _, v in node.entries]):
+                r = self._find_expr_in_ir(item, pred)
+                if r:
+                    return r
+        return None
+
+    def _collect_all_expr_in_actions(self, actions, results=None):
+        if results is None:
+            results = []
+        for action in actions:
+            if isinstance(action, AssignNode):
+                results.append(action.expr)
+            elif isinstance(action, LogNode):
+                results.append(action.expr)
+            elif isinstance(action, SendNode):
+                for e in (action.eventexpr, action.targetexpr, action.delayexpr, action.content_expr):
+                    if e is not None:
+                        results.append(e)
+                for _, e in action.params:
+                    results.append(e)
+            elif isinstance(action, IfNode):
+                for branch in action.branches:
+                    if branch.guard is not None:
+                        results.append(branch.guard)
+                    self._collect_all_expr_in_actions(branch.body, results)
+            elif isinstance(action, ForeachNode):
+                results.append(action.array_expr)
+                self._collect_all_expr_in_actions(action.body, results)
+        return results
+
+    def _collect_all_expr_in_machine(self, machine, results=None):
+        if results is None:
+            results = []
+        if isinstance(machine, MachineIR):
+            for c in machine.children:
+                self._collect_all_expr_in_machine(c, results)
+        elif isinstance(machine, (StateIR, ParallelIR)):
+            for t in machine.transitions:
+                if t.guard is not None:
+                    results.append(t.guard)
+                self._collect_all_expr_in_actions(t.actions, results)
+            self._collect_all_expr_in_actions(machine.onentry, results)
+            self._collect_all_expr_in_actions(machine.onexit, results)
+            for c in machine.children:
+                self._collect_all_expr_in_machine(c, results)
+            for inv in getattr(machine, "invokes", []):
+                if inv.child_machine is not None:
+                    self._collect_all_expr_in_machine(inv.child_machine, results)
+        return results
+
+    def test_parseint_replace_expression_lowered(self, dp_ir):
+        """parseInt(_event.name.replace('taken.','')) must appear as CallNode(int, [CallNode(replace)])."""
+        machine, _ = dp_ir
+        all_exprs = self._collect_all_expr_in_machine(machine)
+
+        def _is_parseint_replace(node):
+            return (
+                isinstance(node, CallNode)
+                and node.func == "int"
+                and len(node.args) == 1
+                and isinstance(node.args[0], CallNode)
+                and node.args[0].func == "replace"
+            )
+
+        found = any(
+            self._find_expr_in_ir(e, _is_parseint_replace) for e in all_exprs
+        )
+        assert found, "parseInt(_event.name.replace(...)) not found in lowered IR"
+
+    def test_t_inputs_indexed_by_event_name_expr(self, dp_ir):
+        """t_INPUTS[_event.name] in <script> bodies lowers to CapabilityCallNode; the
+        expression form t_INPUTS['taken.'+x] in cond attributes lowers to
+        IndexAccess(VarRead('t_INPUTS'), BinOp) in transition guards."""
+        machine, _ = dp_ir
+        all_exprs = self._collect_all_expr_in_machine(machine)
+
+        # t_INPUTS[_event.name] only appears in <script> bodies (CapabilityCallNode);
+        # the equivalent in cond attributes is t_INPUTS['taken.'+i_ID_LEFT] where
+        # the index is a BinOp string concat.  Verify that form is present.
+        def _is_t_inputs_string_key_index(node):
+            return (
+                isinstance(node, IndexAccess)
+                and isinstance(node.obj, VarRead)
+                and node.obj.var == "t_INPUTS"
+                and isinstance(node.index, BinOp)
+            )
+
+        found = any(
+            self._find_expr_in_ir(e, _is_t_inputs_string_key_index) for e in all_exprs
+        )
+        assert found, "t_INPUTS['taken.'+key] IndexAccess not found in lowered IR guards"
+
+    def test_delay_string_concat_expr(self, dp_ir):
+        """i_DELAY_THINK_EAT + 'ms' must appear as a BinOp with + operator."""
+        machine, _ = dp_ir
+        all_exprs = self._collect_all_expr_in_machine(machine)
+
+        def _is_delay_concat(node):
+            # BinOp(+, something, StringLiteral('ms')) or
+            # BinOp(+, CallNode(str, [VarRead(i_DELAY_THINK_EAT)]), StringLiteral('ms'))
+            if not isinstance(node, BinOp) or node.op != "+":
+                return False
+            # Check rhs is string 'ms' or the overall pattern involves 'ms'
+            rhs = node.rhs
+            if isinstance(rhs, StringLiteral) and rhs.s == "ms":
+                return True
+            lhs = node.lhs
+            if isinstance(lhs, StringLiteral) and lhs.s == "ms":
+                return True
+            return False
+
+        found = any(
+            self._find_expr_in_ir(e, _is_delay_concat) for e in all_exprs
+        )
+        assert found, "i_DELAY_THINK_EAT + 'ms' delay expression not found in lowered IR"
+
+    def test_foreach_nodes_present(self, dp_ir):
+        """The DP root parallel transitions include ForeachNode actions (nested foreach)."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        assert isinstance(root, ParallelIR)
+
+        def _has_foreach(actions):
+            for a in actions:
+                if isinstance(a, ForeachNode):
+                    return True
+                if isinstance(a, IfNode):
+                    for branch in a.branches:
+                        if _has_foreach(branch.body):
+                            return True
+            return False
+
+        found = any(_has_foreach(t.actions) for t in root.transitions)
+        assert found, "No ForeachNode found in root parallel transitions"
+
+    def test_nested_foreach_depth_2(self, dp_ir):
+        """The DP 'taken.*' transition has nested foreach (depth 1 outer, depth 2 inner)."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        assert isinstance(root, ParallelIR)
+
+        outer_foreach = None
+        for t in root.transitions:
+            for a in t.actions:
+                if isinstance(a, ForeachNode):
+                    outer_foreach = a
+                    break
+            if outer_foreach is not None:
+                break
+
+        assert outer_foreach is not None
+        # The outer foreach body should contain an inner ForeachNode
+        inner = next((a for a in outer_foreach.body if isinstance(a, ForeachNode)), None)
+        assert inner is not None, "Expected nested ForeachNode inside outer foreach"
+
+    def test_send_with_dynamic_eventexpr(self, dp_ir):
+        """SendNode with dynamic eventexpr must be present in the lowered IR."""
+        machine, _ = dp_ir
+        all_exprs = []
+
+        def _collect_send_nodes(node, acc):
+            if isinstance(node, MachineIR):
+                for c in node.children:
+                    _collect_send_nodes(c, acc)
+            elif isinstance(node, (StateIR, ParallelIR)):
+                for t in node.transitions:
+                    for a in t.actions:
+                        _collect_from_action(a, acc)
+                for a in node.onentry + node.onexit:
+                    _collect_from_action(a, acc)
+                for c in node.children:
+                    _collect_send_nodes(c, acc)
+                for inv in getattr(node, "invokes", []):
+                    if inv.child_machine is not None:
+                        _collect_send_nodes(inv.child_machine, acc)
+
+        def _collect_from_action(action, acc):
+            if isinstance(action, SendNode):
+                acc.append(action)
+            elif isinstance(action, IfNode):
+                for b in action.branches:
+                    for a in b.body:
+                        _collect_from_action(a, acc)
+            elif isinstance(action, ForeachNode):
+                for a in action.body:
+                    _collect_from_action(a, acc)
+
+        send_nodes = []
+        _collect_send_nodes(machine, send_nodes)
+
+        dynamic_sends = [s for s in send_nodes if s.eventexpr is not None]
+        assert dynamic_sends, "No SendNode with dynamic eventexpr found in lowered IR"
+
+    def test_send_with_dynamic_targetexpr(self, dp_ir):
+        """SendNode with dynamic targetexpr (#_parent/#_ID_P_N) must be present."""
+        machine, _ = dp_ir
+        send_nodes = []
+
+        def _collect_from_action(action, acc):
+            if isinstance(action, SendNode):
+                acc.append(action)
+            elif isinstance(action, IfNode):
+                for b in action.branches:
+                    for a in b.body:
+                        _collect_from_action(a, acc)
+            elif isinstance(action, ForeachNode):
+                for a in action.body:
+                    _collect_from_action(a, acc)
+
+        def _collect_send_nodes(node, acc):
+            if isinstance(node, MachineIR):
+                for c in node.children:
+                    _collect_send_nodes(c, acc)
+            elif isinstance(node, (StateIR, ParallelIR)):
+                for t in node.transitions:
+                    for a in t.actions:
+                        _collect_from_action(a, acc)
+                for a in node.onentry + node.onexit:
+                    _collect_from_action(a, acc)
+                for c in node.children:
+                    _collect_send_nodes(c, acc)
+                for inv in getattr(node, "invokes", []):
+                    if inv.child_machine is not None:
+                        _collect_send_nodes(inv.child_machine, acc)
+
+        _collect_send_nodes(machine, send_nodes)
+        dynamic_target = [s for s in send_nodes if s.targetexpr is not None]
+        assert dynamic_target, "No SendNode with dynamic targetexpr found in lowered IR"
+
+    def test_diagnostics_reported_not_crashing(self, dp_ir):
+        """Diagnostics collected during lowering must be accessible, not exceptions."""
+        machine, diags = dp_ir
+        # Diagnostics is a list (may be empty or non-empty; the machine lowered)
+        assert isinstance(diags, list)
+        # Machine must be a valid MachineIR regardless of diagnostic count
+        assert isinstance(machine, MachineIR)
+
+    def test_script_lowers_to_capability_call(self, dp_ir):
+        """<script> elements in the child machine must lower to CapabilityCallNode."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        # Find a Philosopher child
+        phil_state = next(
+            (c for c in root.children if isinstance(c, StateIR) and c.id == "Philosopher1"),
+            None,
+        )
+        assert phil_state is not None
+        cm = phil_state.invokes[0].child_machine
+        assert cm is not None
+
+        def _has_cap_call(node):
+            if isinstance(node, MachineIR):
+                for c in node.children:
+                    if _has_cap_call(c):
+                        return True
+            elif isinstance(node, (StateIR, ParallelIR)):
+                for a in node.onentry + node.onexit:
+                    if isinstance(a, CapabilityCallNode):
+                        return True
+                for t in node.transitions:
+                    for a in t.actions:
+                        if isinstance(a, CapabilityCallNode):
+                            return True
+                for c in node.children:
+                    if _has_cap_call(c):
+                        return True
+            return False
+
+        assert _has_cap_call(cm), "No CapabilityCallNode found in Philosopher1's child machine"
+
+    def test_capability_call_name_synthesis(self, dp_ir):
+        """CapabilityCallNode names must follow the script_<block>_<state>_<idx>_<count> pattern."""
+        machine, _ = dp_ir
+        root = machine.children[0]
+        phil_state = next(
+            (c for c in root.children if isinstance(c, StateIR) and c.id == "Philosopher1"),
+            None,
+        )
+        cm = phil_state.invokes[0].child_machine
+
+        cap_names = []
+
+        def _collect_cap(node):
+            if isinstance(node, MachineIR):
+                for c in node.children:
+                    _collect_cap(c)
+            elif isinstance(node, (StateIR, ParallelIR)):
+                for a in node.onentry + node.onexit:
+                    if isinstance(a, CapabilityCallNode):
+                        cap_names.append(a.name)
+                for t in node.transitions:
+                    for a in t.actions:
+                        if isinstance(a, CapabilityCallNode):
+                            cap_names.append(a.name)
+                for c in node.children:
+                    _collect_cap(c)
+
+        _collect_cap(cm)
+        assert cap_names, "No CapabilityCallNode found"
+        for name in cap_names:
+            assert name.startswith("script_"), \
+                "Cap name {!r} does not start with 'script_'".format(name)
+            assert name.endswith(".success") is False  # names, not events
+
+
+# ---------------------------------------------------------------------------
+# Summary dump helper (used for the keystone report)
+# ---------------------------------------------------------------------------
+
+def test_dp_lowering_summary_dump(capsys):
+    """Print a structural summary of the DP lowering for inspection."""
+    doc = _parse_dp()
+    machine, diags = lower_document(doc)
+
+    def _count_states(node, child_machines=False):
+        count = 0
+        if isinstance(node, MachineIR):
+            for c in node.children:
+                count += _count_states(c, child_machines)
+        elif isinstance(node, (StateIR, ParallelIR)):
+            count += 1
+            for c in node.children:
+                count += _count_states(c, child_machines)
+            if child_machines:
+                for inv in getattr(node, "invokes", []):
+                    if inv.child_machine is not None:
+                        count += _count_states(inv.child_machine, child_machines)
+        elif isinstance(node, FinalIR):
+            count += 1
+        return count
+
+    def _count_transitions_deep(node):
+        count = 0
+        if isinstance(node, MachineIR):
+            for c in node.children:
+                count += _count_transitions_deep(c)
+        elif isinstance(node, (StateIR, ParallelIR)):
+            count += len(node.transitions)
+            for c in node.children:
+                count += _count_transitions_deep(c)
+            for inv in getattr(node, "invokes", []):
+                if inv.child_machine is not None:
+                    count += _count_transitions_deep(inv.child_machine)
+        return count
+
+    def _count_slots_deep(node):
+        count = 0
+        if isinstance(node, MachineIR):
+            count += len(node.datamodel)
+            for c in node.children:
+                count += _count_slots_deep(c)
+        elif isinstance(node, (StateIR, ParallelIR)):
+            count += len(node.datamodel)
+            for c in node.children:
+                count += _count_slots_deep(c)
+            for inv in getattr(node, "invokes", []):
+                if inv.child_machine is not None:
+                    count += _count_slots_deep(inv.child_machine)
+        return count
+
+    def _count_child_machines(node):
+        count = 0
+        if isinstance(node, MachineIR):
+            for c in node.children:
+                count += _count_child_machines(c)
+        elif isinstance(node, (StateIR, ParallelIR)):
+            for inv in getattr(node, "invokes", []):
+                if inv.child_machine is not None:
+                    count += 1
+                    count += _count_child_machines(inv.child_machine)
+            for c in node.children:
+                count += _count_child_machines(c)
+        return count
+
+    total_states = _count_states(machine, child_machines=True)
+    top_states = _count_states(machine, child_machines=False)
+    total_transitions = _count_transitions_deep(machine)
+    total_slots = _count_slots_deep(machine)
+    child_machine_count = _count_child_machines(machine)
+
+    print("\n=== Dining Philosophers IR Lowering Summary ===")
+    print("  Machine name: {}".format(machine.name))
+    print("  Datamodel: {}".format(machine.datamodel_attr))
+    print("  Top-level state count (excluding child machines): {}".format(top_states))
+    print("  Total state count (incl. nested child machines): {}".format(total_states))
+    print("  Inline <invoke> child machines lowered: {}".format(child_machine_count))
+    print("  Total transition count (all machines): {}".format(total_transitions))
+    print("  Total datamodel slot count (all machines): {}".format(total_slots))
+    print("  Diagnostics collected: {}".format(len(diags)))
+    if diags:
+        print("  --- Diagnostics ---")
+        for d in diags:
+            print("    [{}] {} @ {}: {}".format(d.outcome, d.code, d.source_origin, d.message[:80]))
+    print("===================================================")
+
+    # Structural assertions
+    assert isinstance(machine, MachineIR)
+    assert machine.datamodel_attr == "ecmascript"
+    assert child_machine_count == 5
+    assert total_states > 50
+    assert total_transitions > 80
+    assert total_slots > 15

--- a/py/tests/test_exec_ir.py
+++ b/py/tests/test_exec_ir.py
@@ -1165,4 +1165,242 @@ def test_dp_lowering_summary_dump(capsys):
     assert child_machine_count == 5
     assert total_states > 50
     assert total_transitions > 80
-    assert total_slots > 15
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: multi-statement <script> body lowering (D-M1P6-2)
+# ---------------------------------------------------------------------------
+
+
+class TestScriptBodyLowering:
+    """_lower_script correctly lowers admitted script bodies to ActionNode sequences
+    and falls back to CapabilityCallNode for unadmitted / mixed bodies (D-M1P6-2,
+    D-M1P6-8)."""
+
+    def _make_script_obj(self, body: str):
+        """Build a minimal duck-typed Script object with *body* as the value."""
+
+        class _Script:
+            value = body
+            name = None
+
+        return _Script()
+
+    def _make_ecmascript_ctx(self):
+        """Return a _LoweringContext in ECMAScript mode."""
+        from scjson.exec_ir import _LoweringContext
+
+        return _LoweringContext(ecmascript_mode=True, invoke_depth=0)
+
+    def test_all_admitted_assigns_return_sequence(self):
+        """A script body with only assignment statements returns an AssignNode list."""
+        from scjson.exec_ir import _lower_script
+
+        ctx = self._make_ecmascript_ctx()
+        body = 't_INPUTS["taken." + i_ID_LEFT] = 0\nt_INPUTS["taken." + i_ID_RIGHT] = 0'
+        script = self._make_script_obj(body)
+        result = _lower_script(script, ctx, "onentry", "Philospher", 0)
+        assert isinstance(result, list), "Expected list (all-admitted), got {!r}".format(type(result))
+        assert len(result) == 2
+        assert all(isinstance(n, AssignNode) for n in result)
+
+    def test_admitted_if_plus_assigns_returns_sequence(self):
+        """A script body with an if block + assignments returns IfNode + AssignNode list."""
+        from scjson.exec_ir import _lower_script
+
+        ctx = self._make_ecmascript_ctx()
+        # Mirrors the Philosopher onentry script.
+        body = (
+            "if (i_ID !== 0) {\n"
+            "    i_ID_LEFT = t_HAND_COMPLIANCE[i_ID - 1][0]\n"
+            "    i_ID_RIGHT = t_HAND_COMPLIANCE[i_ID - 1][1]\n"
+            "}\n"
+            't_INPUTS["taken." + i_ID_LEFT] = 0\n'
+            't_INPUTS["taken." + i_ID_RIGHT] = 0\n'
+        )
+        script = self._make_script_obj(body)
+        result = _lower_script(script, ctx, "onentry", "Philospher", 0)
+        assert isinstance(result, list), "Expected list, got {!r}".format(type(result))
+        assert len(result) == 3
+        assert isinstance(result[0], IfNode), "First node should be IfNode"
+        assert isinstance(result[1], AssignNode), "Second node should be AssignNode"
+        assert isinstance(result[2], AssignNode), "Third node should be AssignNode"
+        # Verify IfNode has one branch with two assign body nodes.
+        if_node = result[0]
+        assert len(if_node.branches) == 1
+        branch = if_node.branches[0]
+        assert branch.guard is not None
+        assert len(branch.body) == 2
+        assert all(isinstance(n, AssignNode) for n in branch.body)
+
+    def test_mixed_unadmitted_body_returns_capability_call(self):
+        """A script body containing any unadmitted form returns a CapabilityCallNode."""
+        from scjson.exec_ir import _lower_script
+
+        ctx = self._make_ecmascript_ctx()
+        # 'for' loop is inadmissible.
+        body = "for (var i = 0; i < 10; i++) { x = i; }"
+        script = self._make_script_obj(body)
+        result = _lower_script(script, ctx, "onentry", "SomeState", 0)
+        assert isinstance(result, CapabilityCallNode), (
+            "Unadmitted body should produce CapabilityCallNode, got {!r}".format(type(result))
+        )
+
+    def test_mixed_body_admitted_plus_call_returns_capability_call(self):
+        """A mixed body (some admitted, one unadmitted call) returns a CapabilityCallNode.
+
+        Verifies the 'no partial lowering' rule from D-M1P6-2.
+        """
+        from scjson.exec_ir import _lower_script
+
+        ctx = self._make_ecmascript_ctx()
+        # 'console.log(...)' is not admitted; the assignment is admitted but the
+        # block must not be partially lowered.
+        body = "x = 1\nconsole.log(x)"
+        script = self._make_script_obj(body)
+        result = _lower_script(script, ctx, "onentry", "SomeState", 0)
+        assert isinstance(result, CapabilityCallNode), (
+            "Mixed block should fall through to CapabilityCallNode, got {!r}".format(type(result))
+        )
+
+    def test_non_ecmascript_mode_returns_capability_call(self):
+        """In non-ECMAScript mode scripts always produce CapabilityCallNode."""
+        from scjson.exec_ir import _lower_script, _LoweringContext
+
+        ctx = _LoweringContext(ecmascript_mode=False, invoke_depth=0)
+        body = "x = 1"
+        script = self._make_script_obj(body)
+        result = _lower_script(script, ctx, "onentry", "SomeState", 0)
+        assert isinstance(result, CapabilityCallNode)
+
+    def test_simple_transition_script_single_assign(self):
+        """A single-statement script on a transition lowers to one AssignNode."""
+        from scjson.exec_ir import _lower_script
+
+        ctx = self._make_ecmascript_ctx()
+        body = "t_INPUTS[_event.name] = _event.data"
+        script = self._make_script_obj(body)
+        result = _lower_script(script, ctx, "trans", "DiningPhilosophers", 0)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], AssignNode)
+        # Location should represent the subscript assignment target.
+        assert "t_INPUTS" in result[0].loc
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: inline child-machine detection via SCXMLDocumentHandler
+# ---------------------------------------------------------------------------
+
+
+class TestInlineChildMachineDetection:
+    """lower_document populates InvokeIR.child_machine from a
+    SCXMLDocumentHandler-parsed document (which yields dataclasses.Scxml)."""
+
+    @pytest.mark.skipif(
+        not os.path.exists(DP_SCXML_PATH),
+        reason="Dining Philosophers SCXML file not found",
+    )
+    def test_dp_flat_child_machines_populated_via_handler(self):
+        """Loading the FLAT DP file via SCXMLDocumentHandler populates child_machine.
+
+        SCXMLDocumentHandler yields scjson.dataclasses.Scxml (not pydantic.Scxml).
+        Fix 2 makes _lower_invoke recognise both, so this assertion now passes
+        without the backend patch_child_machines workaround.
+        """
+        from scjson.SCXMLDocumentHandler import SCXMLDocumentHandler
+
+        handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+        doc = handler.load(DP_SCXML_PATH)
+        machine, diags = lower_document(doc)
+
+        # Count child machines.
+        def _count_child_machines(ir):
+            count = 0
+            if isinstance(ir, MachineIR):
+                for c in ir.children:
+                    count += _count_child_machines(c)
+            elif isinstance(ir, (StateIR, ParallelIR)):
+                for inv in getattr(ir, "invokes", []):
+                    if inv.child_machine is not None:
+                        count += 1
+                        count += _count_child_machines(inv.child_machine)
+                for c in ir.children:
+                    count += _count_child_machines(c)
+            return count
+
+        child_machine_count = _count_child_machines(machine)
+        assert child_machine_count == 5, (
+            "Expected 5 inline child machines (one per Philosopher), got {}".format(
+                child_machine_count
+            )
+        )
+
+    @pytest.mark.skipif(
+        not os.path.exists(DP_SCXML_PATH),
+        reason="Dining Philosophers SCXML file not found",
+    )
+    def test_dp_flat_philosopher_onentry_script_lowered_to_sequence(self):
+        """The Philosopher onentry script lowers to IfNode + AssignNode + AssignNode.
+
+        This verifies Fix 1 and Fix 2 jointly: the child machine must be
+        populated (Fix 2) for us to inspect its onentry actions, and the
+        script must be lowered to an action sequence (Fix 1) rather than a
+        CapabilityCallNode.
+        """
+        from scjson.SCXMLDocumentHandler import SCXMLDocumentHandler
+
+        handler = SCXMLDocumentHandler(fail_on_unknown_properties=False)
+        doc = handler.load(DP_SCXML_PATH)
+        machine, diags = lower_document(doc)
+
+        # Find the first Philosopher child machine.
+        philosopher_cm: MachineIR | None = None
+        for top in machine.children:  # ParallelIR
+            for state in getattr(top, "children", []):  # StateIR (Philosopher5..1)
+                for inv in getattr(state, "invokes", []):
+                    if inv.child_machine is not None:
+                        philosopher_cm = inv.child_machine
+                        break
+                if philosopher_cm is not None:
+                    break
+            if philosopher_cm is not None:
+                break
+
+        assert philosopher_cm is not None, "No child machine found; Fix 2 may have failed"
+
+        # The root Philospher state carries the onentry with the mixed script.
+        philospher_state: StateIR | None = None
+        for s in philosopher_cm.children:
+            if isinstance(s, StateIR) and getattr(s, "id", "") == "Philospher":
+                philospher_state = s
+                break
+
+        assert philospher_state is not None, "Philospher state not found in child machine"
+
+        onentry = philospher_state.onentry
+        assert len(onentry) >= 3, (
+            "Expected at least 3 onentry actions (IfNode + 2 AssignNodes), "
+            "got {} — Fix 1 may have failed (script still CapabilityCallNode)".format(len(onentry))
+        )
+
+        # First action: IfNode (the if (i_ID !== 0) { ... } block)
+        assert isinstance(onentry[0], IfNode), (
+            "First onentry action should be IfNode, got {!r}".format(type(onentry[0]))
+        )
+        if_node = onentry[0]
+        assert len(if_node.branches) >= 1
+        assert if_node.branches[0].guard is not None
+        # If body: two assigns (i_ID_LEFT, i_ID_RIGHT)
+        assert len(if_node.branches[0].body) == 2
+        assert all(isinstance(n, AssignNode) for n in if_node.branches[0].body)
+
+        # Second + third actions: AssignNodes (t_INPUTS[...] = 0)
+        assert isinstance(onentry[1], AssignNode), (
+            "Second onentry action should be AssignNode, got {!r}".format(type(onentry[1]))
+        )
+        assert isinstance(onentry[2], AssignNode), (
+            "Third onentry action should be AssignNode, got {!r}".format(type(onentry[2]))
+        )
+        assert "t_INPUTS" in onentry[1].loc
+        assert "t_INPUTS" in onentry[2].loc

--- a/py/tests/test_vector_search.py
+++ b/py/tests/test_vector_search.py
@@ -5,11 +5,12 @@ Part of the scjson project.
 Developed by Softoboros Technology Inc.
 Licensed under the BSD 1-Clause License.
 
-Tests for coverage-guided search ordering and pruning.
+Tests for coverage-guided search ordering, pruning, and EXEC-E budget bounds.
 """
 
 from __future__ import annotations
 
+import time
 from typing import Any, Callable
 
 import sys
@@ -20,7 +21,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scjson.context import DocumentContext, ExecutionMode
-from vector_lib.search import generate_sequences
+from vector_lib.search import generate_sequences, SearchResult
 
 
 def _chart_go_noop() -> str:
@@ -42,12 +43,145 @@ def _factory(xml: str) -> Callable[[], DocumentContext]:
     return make
 
 
+def _chart_parallel_invoke_small() -> str:
+    """EXEC-E-D5 regression corpus machine.
+
+    Two parallel regions; region A has one nested inline-<content> <invoke>
+    with a two-state child machine; alphabet of three events (``start``,
+    ``stop``, ``done``).  Small enough to complete well under any CI budget.
+    """
+    return (
+        """
+        <scxml initial="root" xmlns="http://www.w3.org/2005/07/scxml">
+          <parallel id="root">
+            <state id="regionA">
+              <invoke id="child">
+                <content>
+                  <scxml initial="c0" xmlns="http://www.w3.org/2005/07/scxml">
+                    <state id="c0">
+                      <transition event="start" target="c1"/>
+                    </state>
+                    <state id="c1"/>
+                  </scxml>
+                </content>
+              </invoke>
+              <transition event="done" target="regionA"/>
+            </state>
+            <state id="regionB">
+              <transition event="stop" target="regionB"/>
+            </state>
+          </parallel>
+        </scxml>
+        """
+    ).strip()
+
+
 def test_generate_sequences_orders_by_coverage() -> None:
     xml = _chart_go_noop()
     ctx_factory = _factory(xml)
     alphabet: list[Any] = ["noop", "go"]
-    seqs = generate_sequences(ctx_factory, alphabet, max_depth=1, limit=2)
+    result = generate_sequences(ctx_factory, alphabet, max_depth=1, limit=2)
+    seqs = result.sequences
     assert seqs, "expected sequences"
     # 'go' should be ranked before 'noop'
     assert seqs[0] == ["go"]
     # 'noop' may appear later, but is not required
+    # Small machine must not truncate under default budget
+    assert not result.truncated, "small machine must not hit budget"
+
+
+def test_generate_sequences_returns_search_result() -> None:
+    """generate_sequences returns a SearchResult with expected fields."""
+    xml = _chart_go_noop()
+    result = generate_sequences(_factory(xml), ["go"], max_depth=1, limit=1)
+    assert isinstance(result, SearchResult)
+    assert isinstance(result.sequences, list)
+    assert isinstance(result.truncated, bool)
+    assert isinstance(result.candidates_evaluated, int)
+    assert isinstance(result.elapsed_ms, float)
+
+
+def test_candidate_cap_triggers_truncated() -> None:
+    """A max_candidates=1 cap on a multi-event alphabet forces truncated=True."""
+    xml = _chart_go_noop()
+    # alphabet of 3 symbols but cap at 1 candidate — must truncate
+    result = generate_sequences(
+        _factory(xml), ["go", "noop", "other"], max_depth=2, limit=5, max_candidates=1
+    )
+    assert result.truncated, "expected truncated=True when max_candidates exceeded"
+    # Must still return a valid (possibly partial) sequence list — never empty
+    assert result.sequences, "sequences must not be empty even when truncated"
+
+
+def test_time_budget_triggers_truncated() -> None:
+    """A time_budget_ms=1 (1 ms) budget forces truncated=True on any real machine."""
+    xml = _chart_go_noop()
+    result = generate_sequences(
+        _factory(xml), ["go", "noop", "other", "extra"], max_depth=3, limit=5, time_budget_ms=1
+    )
+    # Budget may or may not fire depending on machine speed; if it does, truncated must be set.
+    # What must always hold: result is a SearchResult and sequences is non-empty.
+    assert isinstance(result, SearchResult)
+    assert result.sequences
+
+
+def test_bounded_parallel_invoke_terminates() -> None:
+    """EXEC-E-D5: parallel+invoke machine must complete within budget and return
+    a non-empty result (``success`` or ``limited``).
+
+    This is the regression corpus machine for EXEC-E: two parallel regions,
+    one inline-<content> <invoke> with a two-state child, alphabet of three
+    events.  Under EXEC-E-D2 the effective depth is capped at min(4, 2)=2.
+    """
+    xml = _chart_parallel_invoke_small()
+    alphabet: list[Any] = ["start", "stop", "done"]
+    budget_ms = 10000  # 10 s — well under EXEC-E default; should finish in ms
+
+    t0 = time.monotonic()
+    result = generate_sequences(
+        _factory(xml),
+        alphabet,
+        max_depth=4,  # EXEC-E-D2 will reduce to 2 for parallel+invoke charts
+        limit=3,
+        max_candidates=2000,
+        time_budget_ms=budget_ms,
+    )
+    elapsed_ms = (time.monotonic() - t0) * 1000
+
+    # Must terminate well within the budget
+    assert elapsed_ms < budget_ms, (
+        f"search took {elapsed_ms:.1f} ms, exceeded budget {budget_ms} ms"
+    )
+    # Must return at least one sequence
+    assert result.sequences, "expected at least one sequence"
+    # Must not be empty overall (truncated OR success — both are valid for G1)
+    assert isinstance(result.truncated, bool)
+    # If truncated, sequences may be partial but still non-empty
+    if result.truncated:
+        assert len(result.sequences) >= 1
+    else:
+        # Full result: at least one non-empty sequence should exist
+        assert any(len(s) >= 0 for s in result.sequences)
+
+
+def test_construct_aware_depth_cap_applied() -> None:
+    """EXEC-E-D2: parallel+invoke machine gets effective depth capped at min(max_depth, 2)."""
+    xml = _chart_parallel_invoke_small()
+    alphabet: list[Any] = ["start", "stop", "done"]
+    # Request depth=4 — EXEC-E-D2 must reduce to 2
+    result = generate_sequences(
+        _factory(xml), alphabet, max_depth=4, limit=5, max_candidates=2000, time_budget_ms=10000
+    )
+    # All returned sequences must have length <= 2 (the reduced depth)
+    for seq in result.sequences:
+        assert len(seq) <= 2, (
+            f"sequence length {len(seq)} exceeds reduced depth 2: {seq}"
+        )
+
+
+def test_empty_alphabet_returns_empty_sequence_no_truncation() -> None:
+    """An empty alphabet returns [[]] without triggering truncated."""
+    xml = _chart_go_noop()
+    result = generate_sequences(_factory(xml), [], max_depth=2, limit=1)
+    assert result.sequences == [[]]
+    assert not result.truncated

--- a/py/vector_gen.py
+++ b/py/vector_gen.py
@@ -124,6 +124,8 @@ def generate_vectors(
     limit: int = 1,
     auto_advance: bool = True,
     variants_per_event: int = 3,
+    max_candidates: int = 2000,
+    time_budget_ms: int = 30000,
 ) -> Path:
     """Generate minimal vectors for ``chart`` and write to ``out_dir``.
 
@@ -142,6 +144,13 @@ def generate_vectors(
         sends scheduled during init).
     limit : int
         Maximum number of vectors to emit; Phase 1 uses a single vector.
+    max_candidates : int
+        Maximum BFS candidates to evaluate before stopping with a partial
+        (``limited``) result.  Threaded through to ``generate_sequences``
+        (EXEC-E-D1).  Default: 2000.
+    time_budget_ms : int
+        Wall-clock budget in milliseconds for the BFS search.  Threaded
+        through to ``generate_sequences`` (EXEC-E-D1).  Default: 30000 (30 s).
 
     Returns
     -------
@@ -204,12 +213,18 @@ def generate_vectors(
     ):
         stimuli.append({"event": "complete"})
 
-    sequences = generate_sequences(
+    search_result = generate_sequences(
         _ctx_factory(chart, treat_as_xml, used_advance),
         stimuli,
         max_depth=max_depth,
         limit=limit,
+        max_candidates=max_candidates,
+        time_budget_ms=time_budget_ms,
     )
+    sequences = search_result.sequences
+    # EXEC-E-D4: propagate truncated flag so callers can surface a ``limited``
+    # terminal outcome rather than treating partial results as full-coverage success.
+    search_truncated = search_result.truncated
 
     dest = out_dir / f"{chart.stem}.events.jsonl"
     # Emit only the top sequence for now (aligns with exec_compare consumption)
@@ -289,6 +304,11 @@ def generate_vectors(
             "alphabet": alphabet,
             "payloadHints": {k: len(v) for k, v in payload_hints.items()},
             "sequenceLength": len(top),
+            # EXEC-E-D4: truncated=True signals a ``limited`` outcome to callers
+            # (e.g. iState codegen path at backend/istate/codegen/vectors.py).
+            "truncated": search_truncated,
+            "candidatesEvaluated": search_result.candidates_evaluated,
+            "searchElapsedMs": round(search_result.elapsed_ms, 1),
         }
         (out_dir / f"{chart.stem}.vector.json").write_text(json.dumps(meta, indent=2))
     except Exception:
@@ -311,6 +331,18 @@ def main() -> None:
     ap.add_argument("--no-auto-advance", action="store_true", help="Disable auto-detection of delayed sends during init")
     ap.add_argument("--variants-per-event", type=int, default=3, help="Max fused payload variants to consider per event")
     ap.add_argument("--limit", type=int, default=1, help="Maximum vectors to emit")
+    ap.add_argument(
+        "--max-candidates",
+        type=int,
+        default=2000,
+        help="BFS candidate-count cap (EXEC-E-D1); default 2000",
+    )
+    ap.add_argument(
+        "--time-budget-ms",
+        type=int,
+        default=30000,
+        help="Wall-clock budget in milliseconds for BFS search (EXEC-E-D1); default 30000",
+    )
     args = ap.parse_args()
 
     path = generate_vectors(
@@ -322,6 +354,8 @@ def main() -> None:
         limit=args.limit,
         auto_advance=not args.no_auto_advance,
         variants_per_event=args.variants_per_event,
+        max_candidates=args.max_candidates,
+        time_budget_ms=args.time_budget_ms,
     )
     print(str(path))
 

--- a/py/vector_lib/search.py
+++ b/py/vector_lib/search.py
@@ -10,12 +10,21 @@ Coverage-guided vector search (bounded) for SCXML charts.
 Phase 2 extends the alphabet to support data-bearing stimuli: each symbol in
 the alphabet can be either a plain event name (``str``) or a mapping with
 ``{"event": name, "data": payload}`` (or ``{"name": name, "data": ...}``).
+
+Phase 3 (EXEC-E-D1..D4) adds a candidate-count cap (``max_candidates``) and a
+wall-clock budget (``time_budget_ms``) to guarantee termination on large
+machines.  Charts containing ``<parallel>`` and/or ``<invoke>`` elements
+receive a construct-aware depth/alphabet reduction (EXEC-E-D2).  When the
+budget is exhausted the search returns partial results with ``truncated=True``
+(EXEC-E-D4).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Callable, Iterable, List, Sequence, Tuple
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple
 
 from scjson.context import DocumentContext, ExecutionMode
 from scjson.events import Event
@@ -23,7 +32,37 @@ from .coverage import CoverageTracker
 import json
 
 
+logger = logging.getLogger(__name__)
+
 CtxFactory = Callable[[], DocumentContext]
+
+
+@dataclass
+class SearchResult:
+    """Result returned by ``generate_sequences``.
+
+    Attributes
+    ----------
+    sequences : list[list[Any]]
+        Ordered list of sequences (descending coverage, then length asc, then
+        stable repr tiebreak).  Always non-empty: contains at least ``[[]]``
+        when the alphabet is empty or the budget triggers immediately.
+    truncated : bool
+        ``True`` when the ``while frontier:`` loop was terminated early because
+        ``max_candidates`` was reached or ``time_budget_ms`` elapsed
+        (EXEC-E-D4).  Callers MUST propagate this flag as a ``limited``
+        terminal outcome rather than treating the result as a full-coverage
+        success.
+    candidates_evaluated : int
+        Number of BFS candidates evaluated before the search stopped.
+    elapsed_ms : float
+        Wall-clock time spent inside ``generate_sequences``, in milliseconds.
+    """
+
+    sequences: List[List[Any]]
+    truncated: bool = False
+    candidates_evaluated: int = 0
+    elapsed_ms: float = 0.0
 
 
 def _simulate(ctx: DocumentContext, seq: Sequence[Any]) -> CoverageTracker:
@@ -46,14 +85,55 @@ def _simulate(ctx: DocumentContext, seq: Sequence[Any]) -> CoverageTracker:
     return cov
 
 
+def _detect_complex_constructs(ctx_factory: CtxFactory) -> Tuple[bool, bool]:
+    """Detect whether the chart contains ``<parallel>`` and/or ``<invoke>``.
+
+    Called once before the BFS loop.  Returns ``(has_parallel, has_invoke)``.
+    Detection is static (reads ``ctx.doc`` and ``ctx.activations``); it does
+    not drive any state transitions, so it cannot block.
+
+    Parameters
+    ----------
+    ctx_factory : CtxFactory
+        Factory for a fresh DocumentContext.
+
+    Returns
+    -------
+    tuple[bool, bool]
+        ``(has_parallel, has_invoke)``
+    """
+    try:
+        ctx = ctx_factory()
+        has_parallel = bool(getattr(ctx.doc, "parallel", None))
+        has_invoke = False
+        for _sid, act in ctx.activations.items():
+            if getattr(act, "invokes", None):
+                has_invoke = True
+                break
+        return has_parallel, has_invoke
+    except Exception:
+        # If detection itself fails, default to conservative treatment
+        return False, False
+
+
 def generate_sequences(
     ctx_factory: CtxFactory,
     alphabet: Sequence[Any],
     *,
     max_depth: int = 2,
     limit: int = 1,
-) -> List[List[Any]]:
+    max_candidates: int = 2000,
+    time_budget_ms: int = 30000,
+) -> SearchResult:
     """Generate up to ``limit`` sequences using BFS with coverage pruning.
+
+    The search is bounded by both a candidate-count cap and a wall-clock
+    budget (EXEC-E-D1).  When either limit is reached the loop exits and
+    returns a ``SearchResult`` with ``truncated=True`` (EXEC-E-D4).  Charts
+    containing ``<parallel>`` or ``<invoke>`` elements receive a
+    construct-aware reduction: effective depth is capped at
+    ``min(max_depth, 2)`` and only top-level transition events are used as the
+    stimulus alphabet (EXEC-E-D2).
 
     Parameters
     ----------
@@ -65,23 +145,88 @@ def generate_sequences(
         Maximum sequence length to explore.
     limit : int
         Maximum number of sequences to return.
+    max_candidates : int
+        Maximum cumulative frontier entries to evaluate before stopping.
+        Checked at the top of the ``while frontier:`` loop, before popping.
+        Default: 2000 (EXEC-E-D1 Standards Action).
+    time_budget_ms : int
+        Wall-clock budget in milliseconds measured from function entry.
+        Checked immediately after the ``max_candidates`` check.
+        Default: 30000 (30 s) (EXEC-E-D1 Standards Action).
 
     Returns
     -------
-    list[list[str]]
-        Sequences ordered by descending coverage size and stable tiebreak.
+    SearchResult
+        ``sequences``: list ordered by descending coverage, then length asc,
+        then stable repr tiebreak.  Always has at least one entry (``[[]]``
+        when alphabet is empty or budget fires immediately).
+        ``truncated``: ``True`` when budget or candidate cap was hit.
     """
 
     if not alphabet:
-        return [[]]
+        return SearchResult(sequences=[[]], truncated=False)
+
+    # EXEC-E-D2: Construct-aware reduction.
+    # When the chart contains <parallel> and/or <invoke>, the per-candidate
+    # ctx_factory() cost is O(parallel-regions × inline-invoke-child-machine-
+    # init), making depth > 2 effectively non-terminating on complex machines
+    # (ERRATA-002 root cause).  Cap effective depth at min(max_depth, 2) and
+    # restrict the search alphabet to the top-level transition events already
+    # in `alphabet` (which extract_event_alphabet already provides in
+    # document order — no further reduction is needed here beyond depth).
+    # This reduction is applied statically before the loop.
+    has_parallel, has_invoke = _detect_complex_constructs(ctx_factory)
+    effective_depth = max_depth
+    if has_parallel or has_invoke:
+        effective_depth = min(max_depth, 2)
+        if effective_depth < max_depth:
+            logger.debug(
+                "EXEC-E-D2 construct-aware reduction: chart has parallel=%s invoke=%s; "
+                "capping effective depth %d -> %d (max_candidates=%d, time_budget_ms=%d)",
+                has_parallel,
+                has_invoke,
+                max_depth,
+                effective_depth,
+                max_candidates,
+                time_budget_ms,
+            )
 
     best: List[Tuple[int, List[Any]]] = []
     frontier: List[List[Any]] = [[]]
     seen: set[Tuple[Any, ...]] = set()
+    candidates_evaluated = 0
+    truncated = False
+
+    # EXEC-E-D1: Record entry time for wall-clock budget.
+    t_start = time.monotonic()
 
     while frontier:
+        # EXEC-E-D1: Check candidate-count cap before popping.
+        if candidates_evaluated >= max_candidates:
+            logger.warning(
+                "EXEC-E-D1 budget: max_candidates=%d reached after %.1f ms; "
+                "returning %d partial sequences (truncated)",
+                max_candidates,
+                (time.monotonic() - t_start) * 1000,
+                len(best),
+            )
+            truncated = True
+            break
+        # EXEC-E-D1: Check wall-clock budget immediately after candidate cap.
+        elapsed_ms = (time.monotonic() - t_start) * 1000
+        if elapsed_ms >= time_budget_ms:
+            logger.warning(
+                "EXEC-E-D1 budget: time_budget_ms=%d ms elapsed (%.1f ms actual); "
+                "returning %d partial sequences (truncated)",
+                time_budget_ms,
+                elapsed_ms,
+                len(best),
+            )
+            truncated = True
+            break
+
         seq = frontier.pop(0)
-        if len(seq) >= max_depth:
+        if len(seq) >= effective_depth:
             continue
         for ev in alphabet:
             cand = seq + [ev]
@@ -92,6 +237,7 @@ def generate_sequences(
             if key in seen:
                 continue
             seen.add(key)
+            candidates_evaluated += 1
             ctx = ctx_factory()
             cov = _simulate(ctx, cand)
             score = cov.size()
@@ -99,6 +245,8 @@ def generate_sequences(
             # Keep frontier breadth-limited: expand new candidate if it added anything.
             if score > 0:
                 frontier.append(cand)
+
+    elapsed_ms = (time.monotonic() - t_start) * 1000
 
     # Sort best by coverage score desc, then by length asc, then by stable repr
     def _stable_key(seq: List[Any]) -> str:
@@ -120,4 +268,16 @@ def generate_sequences(
         out.append(seq)
         if len(out) >= max(limit, 1):
             break
-    return out or [[]]
+
+    # EXEC-E-D3 (memoization): TODO — ctx_factory memoization by sequence-prefix
+    # is deferred per spec (optional for first EXEC-E landing; MUST land before
+    # the EXEC-E-D2 depth cap is relaxed for parallel-only charts).  The
+    # candidate-count + wall-clock budget (EXEC-E-D1) is the primary safety net.
+    # Reference: SCJSON-EXEC-00-CONCEPTS.md §EXEC-E-D3 (Specification Required).
+
+    return SearchResult(
+        sequences=out or [[]],
+        truncated=truncated,
+        candidates_evaluated=candidates_evaluated,
+        elapsed_ms=elapsed_ms,
+    )

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scjson (0.4.1)
+    scjson (0.4.2)
       nokogiri
 
 GEM

--- a/ruby/lib/scjson/version.rb
+++ b/ruby/lib/scjson/version.rb
@@ -7,5 +7,5 @@
 # Licensed under the BSD 1-Clause License.
 
 module Scjson
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/ruby/scjson.gemspec
+++ b/ruby/scjson.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'scjson'
-  spec.version     = '0.4.1'
+  spec.version     = '0.4.2'
   spec.summary     = 'SCXML/SCML execution, SCXML <-> scjson converter and validator'
   spec.description = 'scjson: SCXML ↔ JSON converter, validator, and execution trace interface. Provides CLI tools for conversion, validation, and emitting deterministic traces compatible with SCION semantics.'
   spec.authors     = ['Softoboros Technology Inc.']

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scjson"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scjson"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Ira Abbott ira@softobotos.com"]
 edition = "2021"
 license = "BSD-1-Clause"


### PR DESCRIPTION
## Summary
  
  v0.4.2 adds the **constrained-ECMAScript execution + codegen surface** that
  powers the Infinity Stack iState SCXML→Rust generator (parent
  `docs/todo/scjson/TODO-SCJSON-SCRIPT-M1P6.md`). All new behaviour is in the
  **Python** package; the other language packages are a version-only bump to keep
  the release line aligned across registries (see *Packaging* below).
  
  ## Functional changes (Python)
  
  - **Constrained ECMAScript datamodel** (`datamodel="ecmascript"`) — new
    `scjson.ecmascript_normalizer` lowers the admitted JS subset (M1P6 D-M1P6-2:
    `&&`/`||`/`!`, `===`/`!==`, `parseInt`/`String`/`Number`, `<str>.replace`,
    object/array literals, computed member access, dynamic map keys,
    `if`/assignment statement bodies) to Python-evaluable forms. Unadmitted forms
    emit an `unsupported-ecmascript` diagnostic — never a silent mis-eval.
    `null`/`python` datamodels are byte-for-byte unchanged.
  - **M1 Executable IR** (`scjson.exec_ir` + `lower_document`) — the M1P6 value
    model, 7 ExpressionNode + 7 ActionNode families, `<foreach>`,
    inline-`<content>` `<invoke>` → depth-bounded nested machine IR, dynamic
    `<send>` slots, recursive state tree. Admitted multi-statement `<script>`
    bodies lower to `AssignNode`/`IfNode` sequences (otherwise blocked whole as a
    capability call). Additive layer; does not change engine execution.
  - **Bounded vector-generation coverage search** (`vector_lib/search.py`,
    `vector_gen.py`) — `max_candidates` + `time_budget_ms` budgets +
    construct-aware depth reduction for `<parallel>`/`<invoke>`. Budget exhaustion
    now yields a terminal `limited` result (`truncated: true`) instead of an
    unbounded hang.
    
  ## Errata
  
  - **ERRATA-002** (resolved) — `<parallel>`+`<invoke>` vector-gen hang, fixed by
    the bounded search above. See `docs/concepts/SCJSON-EXEC-00-CONCEPTS.md`
    §EXEC-E.
  - **ERRATA-003** (documented) — `In()` cross-region predicate gap (blocks the
    faithful Bolero media core); recorded, not yet closed.
    
  ## Packaging
  
  - `py/` → **0.4.2** (functional release above).
  - `js/`, `ruby/`, `rust/`, `java/` → **0.4.2 version-only** (no functional
    change since 0.4.1) so the per-language publish tags are consistent and
    downstream consumers can pin a single 0.4.2 line. Lockfile self-version
    fields synced; coincidental `0.4.1` dependency pins (e.g. `json-schema-traverse`,
    `levn`) left untouched.
    
  ## Publish (tag-triggered CI)
  
  Push the per-language tags after merge: `pypi-0.4.2`, `npm-0.4.2`
  (+ `crates-0.4.2`, `rubygems-0.4.2` for full parity). 
  
  ## Delta
  
  - `835ecd0` release(0.4.2): cross-language version sync (js/rust/ruby/java)
  - `739c8a8` release-prep: Python version + changelogs + ERRATA-003 (In() gap)
  - `11cc635` M1P6 G2: lower admitted `<script>` statement sequences + robust inline-child detection
  - `603ad45` M1P6 G2: implement M1 Executable IR + SCJSON→IR lowerer
  - `133a71b` M1P6 G2: admit constrained ECMAScript subset in the execution engine
  - `9d76435` EXEC-E: bound vector-generation coverage search (fixes ERRATA-002 hang)
  
 